### PR TITLE
interface: spi: refactor SPI interface and implementation

### DIFF
--- a/interfaces/spi/include/libmcu/spi.h
+++ b/interfaces/spi/include/libmcu/spi.h
@@ -25,52 +25,113 @@ typedef enum {
 	SPI_MODE_3, /* CPOL=1, CPHA=1 */
 } spi_mode_t;
 
-struct spi;
-struct spi_device;
-
-struct spi_api {
-	struct spi_device *(*enable)(struct spi *self,
-			spi_mode_t mode, uint32_t freq_hz, int pin_cs);
-	int (*disable)(struct spi_device *dev);
-	int (*write)(struct spi_device *dev,
-			const void *data, size_t data_len);
-	int (*read)(struct spi_device *dev, void *buf, size_t bufsize);
-	int (*writeread)(struct spi_device *dev, const void *txdata,
-			size_t txdata_len, void *rxbuf, size_t rxbuf_len);
-};
-
 struct spi_pin {
 	int miso;
 	int mosi;
 	int sclk;
 };
 
-static inline struct spi_device *spi_enable(struct spi *self,
-		spi_mode_t mode, uint32_t freq_hz, int pin_cs) {
-	return ((struct spi_api *)self)->enable(self, mode, freq_hz, pin_cs);
-}
+struct spi;
+struct spi_device;
 
-static inline int spi_disable(struct spi_device *dev) {
-	return ((struct spi_api *)dev)->disable(dev);
-}
-
-static inline int spi_write(struct spi_device *dev,
-		const void *data, size_t data_len) {
-	return ((struct spi_api *)dev)->write(dev, data, data_len);
-}
-
-static inline int spi_read(struct spi_device *dev, void *buf, size_t bufsize) {
-	return ((struct spi_api *)dev)->read(dev, buf, bufsize);
-}
-
-static inline int spi_writeread(struct spi_device *dev, const void *txdata,
-		size_t txdata_len, void *rxbuf, size_t rxbuf_len) {
-	return ((struct spi_api *)dev)->writeread(dev,
-			txdata, txdata_len, rxbuf, rxbuf_len);
-}
-
+/**
+ * @brief Create a SPI instance.
+ *
+ * This function creates a SPI instance associated with the given channel and
+ * pin.
+ *
+ * @param[in] channel The channel to be associated with the SPI instance.
+ * @param[in] pin The pin to be associated with the SPI instance.
+ *
+ * @return A pointer to the created SPI instance. If the creation fails,
+ *         the function returns NULL.
+ */
 struct spi *spi_create(uint8_t channel, const struct spi_pin *pin);
+
+/**
+ * @brief Delete a SPI instance.
+ *
+ * This function deletes a SPI instance and frees the associated resources.
+ *
+ * @param[in] self The SPI instance to be deleted.
+ */
 void spi_delete(struct spi *self);
+
+/**
+ * @brief Enable a SPI device.
+ *
+ * This function enables a SPI device with a given mode, frequency, and chip
+ * select pin.
+ *
+ * @param[in] self The SPI instance.
+ * @param[in] mode The SPI mode.
+ * @param[in] freq_hz The frequency of the SPI signal in Hz.
+ * @param[in] pin_cs The chip select pin for the SPI device.
+ *
+ * @return A pointer to the enabled SPI device. If the operation fails,
+ *         the function returns NULL.
+ */
+struct spi_device *spi_enable(struct spi *self,
+		spi_mode_t mode, uint32_t freq_hz, int pin_cs);
+
+/**
+ * @brief Disable a SPI device.
+ *
+ * This function disables a SPI device and frees the associated resources.
+ *
+ * @param[in] dev The SPI device to be disabled.
+ *
+ * @return 0 if the operation is successful, otherwise returns a non-zero error
+ *         code.
+ */
+int spi_disable(struct spi_device *dev);
+
+/**
+ * @brief Write data to a SPI device.
+ *
+ * This function writes data to a SPI device.
+ *
+ * @param[in] dev The SPI device.
+ * @param[in] data The data to be written.
+ * @param[in] data_len The length of the data to be written.
+ *
+ * @return 0 if the operation is successful, otherwise returns a non-zero error
+ *         code.
+ */
+int spi_write(struct spi_device *dev, const void *data, size_t data_len);
+
+/**
+ * @brief Read data from a SPI device.
+ *
+ * This function reads data from a SPI device into a buffer.
+ *
+ * @param[in] dev The SPI device.
+ * @param[out] buf The buffer where the read data will be stored.
+ * @param[in] bufsize The size of the buffer.
+ *
+ * @return 0 if the operation is successful, otherwise returns a non-zero error
+ *         code.
+ */
+int spi_read(struct spi_device *dev, void *buf, size_t bufsize);
+
+/**
+ * @brief Write and read data from a SPI device.
+ *
+ * This function writes data to a SPI device and then reads data from the
+ * device.
+ *
+ * @param[in] dev The SPI device.
+ * @param[in] txdata The data to be written.
+ * @param[in] txdata_len The length of the data to be written.
+ * @param[out] rxbuf The buffer where the read data will be stored.
+ * @param[in] rxbuf_len The size of the buffer.
+ *
+ * @return 0 if the operation is successful, otherwise returns a non-zero error
+ *         code.
+ */
+int spi_writeread(struct spi_device *dev,
+		const void *txdata, size_t txdata_len,
+		void *rxbuf, size_t rxbuf_len);
 
 #if defined(__cplusplus)
 }

--- a/ports/esp-idf/spi.c
+++ b/ports/esp-idf/spi.c
@@ -28,7 +28,6 @@ struct spi_device {
 };
 
 struct spi {
-	struct spi_api api;
 	struct spi_pin pin;
 
 	spi_host_device_t host;
@@ -114,7 +113,7 @@ static int convert_freq_to_clock_div(uint32_t freq_hz)
 	return SPI_MASTER_FREQ_8M;
 }
 
-static int write_spi(struct spi_device *dev, const void *data, size_t data_len)
+int spi_write(struct spi_device *dev, const void *data, size_t data_len)
 {
 	if (!data || data_len == 0) {
 		return -EINVAL;
@@ -133,8 +132,9 @@ static int write_spi(struct spi_device *dev, const void *data, size_t data_len)
 	return (int)data_len;
 }
 
-static int writeread(struct spi_device *dev, const void *txdata, size_t txdata_len,
-		       void *rxbuf, size_t rxbuf_len)
+int spi_writeread(struct spi_device *dev,
+		const void *txdata, size_t txdata_len,
+		void *rxbuf, size_t rxbuf_len)
 {
 	int rc = 0;
 	uint8_t *buf = (uint8_t *)calloc(1, txdata_len + rxbuf_len);
@@ -164,7 +164,7 @@ static int writeread(struct spi_device *dev, const void *txdata, size_t txdata_l
 	return rc;
 }
 
-static int read_spi(struct spi_device *dev, void *buf, size_t bufsize)
+int spi_read(struct spi_device *dev, void *buf, size_t bufsize)
 {
 	unused(dev);
 	unused(buf);
@@ -172,7 +172,7 @@ static int read_spi(struct spi_device *dev, void *buf, size_t bufsize)
 	return -ENOTSUP;
 }
 
-static struct spi_device *enable_spi(struct spi *self,
+struct spi_device *spi_enable(struct spi *self,
 		spi_mode_t mode, uint32_t freq_hz, int pin_cs)
 {
 	esp_err_t ret;
@@ -211,7 +211,7 @@ static struct spi_device *enable_spi(struct spi *self,
 	return device;
 }
 
-static int disable_spi(struct spi_device *dev)
+int spi_disable(struct spi_device *dev)
 {
 	esp_err_t err = spi_bus_remove_device(dev->handle);
 
@@ -232,13 +232,6 @@ struct spi *spi_create(uint8_t channel, const struct spi_pin *pin)
 	}
 
 	channel -= 2;
-	spi[channel].api = (struct spi_api) {
-		.enable = enable_spi,
-		.disable = disable_spi,
-		.write = write_spi,
-		.read = read_spi,
-		.writeread = writeread,
-	};
 
 	switch (channel) {
 	case 0:


### PR DESCRIPTION
This pull request refactors the SPI interface by removing the `spi_api` structure and converting its methods into standalone functions with detailed documentation. Additionally, the implementation in `spi.c` has been updated to reflect these changes.

### Refactoring and Documentation:

* [`interfaces/spi/include/libmcu/spi.h`](diffhunk://#diff-2100b036dba47edf75b3e75c46c178673e25f4ba2debdca5278e3f840558e448L28-R134): Removed the `spi_api` structure and added standalone functions with detailed documentation for creating, deleting, enabling, disabling, reading from, writing to, and writing/reading from a SPI device.

### Implementation Updates:

* [`ports/esp-idf/spi.c`](diffhunk://#diff-d94c5bf030779b5bcca4eb58ee3f1cd6d5f303a27bd8f3bb00c555ad45ada1daL31): Removed the `spi_api` structure from `struct spi` and converted its methods (`enable_spi`, `disable_spi`, `write_spi`, `read_spi`, `writeread`) into standalone functions. [[1]](diffhunk://#diff-d94c5bf030779b5bcca4eb58ee3f1cd6d5f303a27bd8f3bb00c555ad45ada1daL31) [[2]](diffhunk://#diff-d94c5bf030779b5bcca4eb58ee3f1cd6d5f303a27bd8f3bb00c555ad45ada1daL117-R116) [[3]](diffhunk://#diff-d94c5bf030779b5bcca4eb58ee3f1cd6d5f303a27bd8f3bb00c555ad45ada1daL136-R136) [[4]](diffhunk://#diff-d94c5bf030779b5bcca4eb58ee3f1cd6d5f303a27bd8f3bb00c555ad45ada1daL167-R175) [[5]](diffhunk://#diff-d94c5bf030779b5bcca4eb58ee3f1cd6d5f303a27bd8f3bb00c555ad45ada1daL214-R214) [[6]](diffhunk://#diff-d94c5bf030779b5bcca4eb58ee3f1cd6d5f303a27bd8f3bb00c555ad45ada1daL235-L241)