### PR TITLE
port: esp-idf: optimize memory usage in spi_writeread

### DIFF
--- a/ports/esp-idf/spi.c
+++ b/ports/esp-idf/spi.c
@@ -106,7 +106,7 @@ static int convert_freq_to_clock_div(uint32_t freq_hz)
 		return SPI_MASTER_FREQ_11M;
 	} else if (freq_hz >= 10000000) {
 		return SPI_MASTER_FREQ_10M;
-	} else {
+	} else if (freq_hz >= 9000000){
 		return SPI_MASTER_FREQ_9M;
 	}
 
@@ -137,29 +137,17 @@ int spi_writeread(struct spi_device *dev,
 		void *rxbuf, size_t rxbuf_len)
 {
 	int rc = 0;
-	uint8_t *buf = (uint8_t *)calloc(1, txdata_len + rxbuf_len);
-
-	if (buf == NULL) {
-		return -ENOMEM;
-	}
-
-	memcpy(buf, txdata, txdata_len);
-
 	spi_transaction_t transaction = {
 		.length = txdata_len * 8,
 		.rxlength = rxbuf_len * 8,
-		.tx_buffer = buf,
-		.rx_buffer = &buf[txdata_len],
+		.tx_buffer = txdata,
+		.rx_buffer = rxbuf,
 		.user = (void *)dev,
 	};
 
 	if (spi_device_transmit(dev->handle, &transaction) != ESP_OK) {
 		rc = -EIO;
 	}
-
-	memcpy(rxbuf, &buf[txdata_len], rxbuf_len);
-
-	free(buf);
 
 	return rc;
 }


### PR DESCRIPTION
This pull request includes changes to the SPI communication implementation in the `spi.c` file to improve performance and memory usage. The most important changes include modifying the frequency-to-clock divider conversion logic and optimizing the `spi_writeread` function by removing unnecessary memory allocations and copies.

Changes to frequency-to-clock divider conversion:

* [`ports/esp-idf/spi.c`](diffhunk://#diff-d94c5bf030779b5bcca4eb58ee3f1cd6d5f303a27bd8f3bb00c555ad45ada1daL109-R109): Adjusted the frequency-to-clock divider conversion logic to include a specific case for frequencies greater than or equal to 9 MHz. (`static int convert_freq_to_clock_div(uint32_t freq_hz)`)

Optimizations in `spi_writeread` function:

* [`ports/esp-idf/spi.c`](diffhunk://#diff-d94c5bf030779b5bcca4eb58ee3f1cd6d5f303a27bd8f3bb00c555ad45ada1daL140-L163): Removed dynamic memory allocation and copying in the `spi_writeread` function, directly using the provided transmit and receive buffers instead. (`int spi_writeread(struct spi_device *dev, void *rxbuf, size_t rxbuf_len)`)