### PR TITLE
runner: fix missing the post callback after runner change

### DIFF
--- a/modules/runner/src/runner.c
+++ b/modules/runner/src/runner.c
@@ -74,20 +74,25 @@ runner_t runner_current_type(void)
 
 int runner_change(const runner_t new_runner_type)
 {
+	int rc = 0;
+
 	if (new_runner_type == get_current_type()) {
-		return -EALREADY;
+		rc = -EALREADY;
+		goto out;
 	}
 
 	const struct runner *old_runner = get_current();
 	const struct runner *new_runner = find_runner_by_type(new_runner_type);
 
 	if (new_runner == NULL) {
-		return -EINVAL;
+		rc = -EINVAL;
+		goto out;
 	}
 
 	if (m.pre_change_cb) {
 		if (!m.pre_change_cb(new_runner_type, m.pre_change_cb_ctx)) {
-			return -EFAULT;
+			rc = -EFAULT;
+			goto out;
 		}
 	}
 
@@ -98,14 +103,15 @@ int runner_change(const runner_t new_runner_type)
 	set_current(new_runner);
 
 	if (new_runner->api->prepare) {
-		return new_runner->api->prepare();
+		rc = new_runner->api->prepare();
 	}
 
 	if (m.post_change_cb) {
 		m.post_change_cb(new_runner_type, m.post_change_cb_ctx);
 	}
 
-	return 0;
+out:
+	return rc;
 }
 
 void runner_start(const runner_t runner_type)


### PR DESCRIPTION
This pull request includes changes to the error handling in the `runner_change` function within the `modules/runner/src/runner.c` file. The function now uses a common exit point for error handling, improving readability and maintainability.

Error handling improvements:

* [`modules/runner/src/runner.c`](diffhunk://#diff-d96c3d5ec98aa98e69ef9cc3c16731904827356340445f68deb962f5bf6347bcR79-R97): Modified `runner_change` to use a common exit point with the `goto` statement for error handling, replacing multiple `return` statements with a single `out` label. [[1]](diffhunk://#diff-d96c3d5ec98aa98e69ef9cc3c16731904827356340445f68deb962f5bf6347bcR79-R97) [[2]](diffhunk://#diff-d96c3d5ec98aa98e69ef9cc3c16731904827356340445f68deb962f5bf6347bcL103-R116)