### PR TITLE
interface: refactor PWM and SPI interfaces

### DIFF
--- a/interfaces/pwm/include/libmcu/pwm.h
+++ b/interfaces/pwm/include/libmcu/pwm.h
@@ -31,6 +31,7 @@ struct pwm_channel;
  *         the function returns NULL.
  */
 struct pwm *pwm_create(uint8_t timer);
+
 /**
  * @brief Delete a PWM instance.
  *
@@ -43,29 +44,43 @@ struct pwm *pwm_create(uint8_t timer);
 int pwm_delete(struct pwm *self);
 
 /**
- * @brief Enable a PWM channel.
+ * Creates a new PWM channel.
  *
- * This function enables a PWM channel on a given pin. If the channel is 
- * already enabled, it will be reconfigured.
+ * @param[in] self A pointer to the PWM structure.
+ * @param[in] ch The channel number.
+ * @param[in] pin The pin number.
  *
- * @param[in] self The PWM instance.
- * @param[in] ch The channel to be enabled.
- * @param[in] pin The pin where the PWM signal will be output.
- *
- * @return A pointer to the enabled PWM channel. If the operation fails,
- *         the function returns NULL.
+ * @return A pointer to the created PWM channel.
  */
-struct pwm_channel *pwm_enable(struct pwm *self, int ch, int pin);
+struct pwm_channel *pwm_create_channel(struct pwm *self, int ch, int pin);
+
 /**
- * @brief Disable a PWM channel.
+ * Deletes a PWM channel.
  *
- * This function disables a PWM channel and frees the associated resources.
+ * @param[in] ch A pointer to the PWM channel to delete.
  *
- * @param[in] ch The PWM channel to be disabled.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int pwm_delete_channel(struct pwm_channel *ch);
+
+/**
+ * Enables a PWM channel.
  *
- * @return 0 if the operation is successful, otherwise returns a non-zero error code.
+ * @param[in] ch A pointer to the PWM channel to enable.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
+int pwm_enable(struct pwm_channel *ch);
+
+/**
+ * Disables a PWM channel.
+ *
+ * @param[in] ch A pointer to the PWM channel to disable.
+ *
+ * @return 0 on success, or a negative error code on failure.
  */
 int pwm_disable(struct pwm_channel *ch);
+
 /**
  * @brief Start a PWM channel.
  *
@@ -78,6 +93,7 @@ int pwm_disable(struct pwm_channel *ch);
  * @return 0 if the operation is successful, otherwise returns a non-zero error code.
  */
 int pwm_start(struct pwm_channel *ch, uint32_t freq_hz, uint32_t duty_millipercent);
+
 /**
  * @brief Stop a PWM channel.
  *

--- a/interfaces/spi/include/libmcu/spi.h
+++ b/interfaces/spi/include/libmcu/spi.h
@@ -58,31 +58,42 @@ struct spi *spi_create(uint8_t channel, const struct spi_pin *pin);
 void spi_delete(struct spi *self);
 
 /**
- * @brief Enable a SPI device.
+ * Creates a new SPI device.
  *
- * This function enables a SPI device with a given mode, frequency, and chip
- * select pin.
- *
- * @param[in] self The SPI instance.
+ * @param[in] self A pointer to the SPI structure.
  * @param[in] mode The SPI mode.
- * @param[in] freq_hz The frequency of the SPI signal in Hz.
- * @param[in] pin_cs The chip select pin for the SPI device.
+ * @param[in] freq_hz The frequency in Hz.
+ * @param[in] pin_cs The chip select pin.
  *
- * @return A pointer to the enabled SPI device. If the operation fails,
- *         the function returns NULL.
+ * @return A pointer to the created SPI device.
  */
-struct spi_device *spi_enable(struct spi *self,
+struct spi_device *spi_create_device(struct spi *self,
 		spi_mode_t mode, uint32_t freq_hz, int pin_cs);
 
 /**
- * @brief Disable a SPI device.
+ * Deletes an SPI device.
  *
- * This function disables a SPI device and frees the associated resources.
+ * @param[in] dev A pointer to the SPI device to delete.
  *
- * @param[in] dev The SPI device to be disabled.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int spi_delete_device(struct spi_device *dev);
+
+/**
+ * Enables an SPI device.
  *
- * @return 0 if the operation is successful, otherwise returns a non-zero error
- *         code.
+ * @param[in] dev A pointer to the SPI device to enable.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
+int spi_enable(struct spi_device *dev);
+
+/**
+ * Disables an SPI device.
+ *
+ * @param[in] dev A pointer to the SPI device to disable.
+ *
+ * @return 0 on success, or a negative error code on failure.
  */
 int spi_disable(struct spi_device *dev);
 


### PR DESCRIPTION
This pull request includes significant updates to the PWM and SPI interfaces, primarily focusing on the creation, deletion, and management of channels and devices. The changes introduce new functions, enhance existing ones, and improve resource management.

### PWM Interface Updates:

* Added `pwm_create_channel` and `pwm_delete_channel` functions to manage PWM channels. (`interfaces/pwm/include/libmcu/pwm.h`)
* Modified `pwm_enable` and `pwm_disable` to handle channel enabling and disabling more robustly. (`interfaces/pwm/include/libmcu/pwm.h`)
* Added an `enabled` flag to the `pwm_channel` structure to track the state of PWM channels. (`ports/esp-idf/pwm.c`)
* Implemented `pwm_enable` and `pwm_disable` functions to control the enabled state of PWM channels. (`ports/esp-idf/pwm.c`) [[1]](diffhunk://#diff-4b8e57a85f057ec4c6806637bed031c938fbeb22c8e30a22421cf4d5aa966609L148-R171) [[2]](diffhunk://#diff-4b8e57a85f057ec4c6806637bed031c938fbeb22c8e30a22421cf4d5aa966609L157-R185)

### SPI Interface Updates:

* Added `spi_create_device` and `spi_delete_device` functions to manage SPI devices. (`interfaces/spi/include/libmcu/spi.h`)
* Modified `spi_enable` and `spi_disable` to handle device enabling and disabling more effectively. (`interfaces/spi/include/libmcu/spi.h`)
* Added an `enabled` flag to the `spi_device` structure to track the state of SPI devices. (`ports/esp-idf/spi.c`)
* Implemented `disable_spi_device` to centralize the logic for disabling SPI devices. (`ports/esp-idf/spi.c`)

These changes improve the overall functionality and robustness of the PWM and SPI interfaces by introducing better resource management and clearer function definitions.