### PR TITLE
metrics: add is_set flag to track metric updates

### DIFF
--- a/modules/metrics/src/metrics.c
+++ b/modules/metrics/src/metrics.c
@@ -25,6 +25,7 @@ static_assert(METRICS_KEY_MAX < (1U << sizeof(metric_key_t) * 8),
 struct metrics {
 	metric_key_t key;
 	int32_t value;
+	bool is_set;
 } LIBMCU_PACKED;
 
 LIBMCU_NOINIT static struct metrics metrics[METRICS_KEY_MAX+1/*magic*/];
@@ -59,12 +60,30 @@ static struct metrics *get_obj_from_key(metric_key_t key)
 	return get_item_by_index(get_index_by_key(key));
 }
 
+static bool is_metric_set(const struct metrics *p)
+{
+	return p->is_set;
+}
+
+static void set_metric_value(metric_key_t key, int32_t value)
+{
+	get_obj_from_key(key)->value = value;
+	get_obj_from_key(key)->is_set = true;
+}
+
+static int32_t get_metric_value(metric_key_t key)
+{
+	return get_obj_from_key(key)->value;
+}
+
 static void iterate_all(void (*callback_each)(metric_key_t key, int32_t value,
 					      void *ctx), void *ctx)
 {
 	for (metric_key_t i = 0; i < METRICS_KEY_MAX; i++) {
 		struct metrics const *p = get_item_by_index(i);
-		callback_each(p->key, p->value, ctx);
+		if (is_metric_set(p)) {
+			callback_each(p->key, p->value, ctx);
+		}
 	}
 }
 
@@ -73,16 +92,17 @@ static void reset_all(void)
 	for (metric_key_t i = 0; i < METRICS_KEY_MAX; i++) {
 		get_item_by_index(i)->key = i;
 		get_item_by_index(i)->value = 0;
+		get_item_by_index(i)->is_set = false;
 	}
 }
 
-static uint32_t count_metrics_with_nonzero_value(void)
+static uint32_t count_metrics_updated(void)
 {
 	uint32_t nr_updated = 0;
 
 	for (metric_key_t i = 0; i < METRICS_KEY_MAX; i++) {
 		struct metrics const *p = get_item_by_index(i);
-		if (p->value != 0) {
+		if (is_metric_set(p)) {
 			nr_updated++;
 		}
 	}
@@ -93,12 +113,14 @@ static uint32_t count_metrics_with_nonzero_value(void)
 static size_t encode_all(uint8_t *buf, size_t bufsize)
 {
 	size_t written = metrics_encode_header(buf, bufsize,
-			METRICS_KEY_MAX, count_metrics_with_nonzero_value());
+			METRICS_KEY_MAX, count_metrics_updated());
 
 	for (metric_key_t i = 0; i < METRICS_KEY_MAX; i++) {
 		struct metrics const *p = get_item_by_index(i);
-		written += metrics_encode_each(&buf[written], bufsize - written,
-				p->key, p->value);
+		if (is_metric_set(p)) {
+			written += metrics_encode_each(&buf[written],
+					bufsize - written, p->key, p->value);
+		}
 	}
 
 	return written;
@@ -112,7 +134,7 @@ static void initialize_metrics(void)
 void metrics_set(metric_key_t key, int32_t val)
 {
 	metrics_lock();
-	get_obj_from_key(key)->value = val;
+	set_metric_value(key, val);
 	metrics_unlock();
 }
 
@@ -121,7 +143,7 @@ int32_t metrics_get(metric_key_t key)
 	int32_t value;
 
 	metrics_lock();
-	value = get_obj_from_key(key)->value;
+	value = get_metric_value(key);
 	metrics_unlock();
 
 	return value;
@@ -130,14 +152,14 @@ int32_t metrics_get(metric_key_t key)
 void metrics_increase(metric_key_t key)
 {
 	metrics_lock();
-	get_obj_from_key(key)->value++;
+	set_metric_value(key, get_metric_value(key) + 1);
 	metrics_unlock();
 }
 
 void metrics_increase_by(metric_key_t key, int32_t n)
 {
 	metrics_lock();
-	get_obj_from_key(key)->value += n;
+	set_metric_value(key, get_metric_value(key) + n);
 	metrics_unlock();
 }
 

--- a/ports/metrics/cbor_encoder.c
+++ b/ports/metrics/cbor_encoder.c
@@ -23,10 +23,6 @@ size_t metrics_encode_header(void *buf, size_t bufsize,
 size_t metrics_encode_each(void *buf, size_t bufsize,
 		metric_key_t key, int32_t value)
 {
-	if (value == 0) {
-		return 0;
-	}
-
 	size_t len = cbor_writer_len(&writer);
 
 	cbor_encode_unsigned_integer(&writer, (uint64_t)key);

--- a/tests/src/metrics/test_metrics.cpp
+++ b/tests/src/metrics/test_metrics.cpp
@@ -129,7 +129,7 @@ TEST(metrics, collect_ShouldReturnSizeOfAllEncodedMetrics_WhenZeroedValueGiven) 
 	uint8_t expected_encoded_data[128] = { 0, };
 	uint8_t buf[128];
 	size_t size = metrics_collect(buf, sizeof(buf));
-	LONGS_EQUAL(28, size);
+	LONGS_EQUAL(0, size);
 	MEMCMP_EQUAL(expected_encoded_data, buf, size);
 }
 
@@ -138,7 +138,7 @@ TEST(metrics, collect_ShouldReturnSizeOfAllEncodedMetrics_WhenReportIntervalValu
 	uint8_t buf[128];
 	metrics_set(ReportInterval, 0x12345678);
 	size_t size = metrics_collect(buf, sizeof(buf));
-	LONGS_EQUAL(28, size);
+	LONGS_EQUAL(4, size);
 	MEMCMP_EQUAL(expected_encoded_data, buf, size);
 }
 


### PR DESCRIPTION
This pull request introduces significant updates to the metrics module to improve how metric values are managed and encoded. The changes primarily focus on adding a flag to indicate if a metric is set and refactoring the code to use this flag for various operations.

### Enhancements to Metrics Management:

* [`modules/metrics/src/metrics.c`](diffhunk://#diff-ca99a650d80f8677686a9fea3e066f9a0f789c17980aa577f8ca2b3b35832d3fR28): Added a `bool is_set` field to the `metrics` struct to track if a metric is set.
* [`modules/metrics/src/metrics.c`](diffhunk://#diff-ca99a650d80f8677686a9fea3e066f9a0f789c17980aa577f8ca2b3b35832d3fR63-R105): Introduced helper functions `is_metric_set`, `set_metric_value`, and `get_metric_value` to manage metric values and their set status. These functions are used throughout the module to ensure consistency. [[1]](diffhunk://#diff-ca99a650d80f8677686a9fea3e066f9a0f789c17980aa577f8ca2b3b35832d3fR63-R105) [[2]](diffhunk://#diff-ca99a650d80f8677686a9fea3e066f9a0f789c17980aa577f8ca2b3b35832d3fL115-R137) [[3]](diffhunk://#diff-ca99a650d80f8677686a9fea3e066f9a0f789c17980aa577f8ca2b3b35832d3fL124-R146) [[4]](diffhunk://#diff-ca99a650d80f8677686a9fea3e066f9a0f789c17980aa577f8ca2b3b35832d3fL133-R162)

### Code Refactoring for Consistency:

* [`modules/metrics/src/metrics.c`](diffhunk://#diff-ca99a650d80f8677686a9fea3e066f9a0f789c17980aa577f8ca2b3b35832d3fR63-R105): Updated the `iterate_all`, `reset_all`, and `count_metrics_updated` functions to utilize the new `is_set` flag for more accurate and efficient operations. [[1]](diffhunk://#diff-ca99a650d80f8677686a9fea3e066f9a0f789c17980aa577f8ca2b3b35832d3fR63-R105) [[2]](diffhunk://#diff-ca99a650d80f8677686a9fea3e066f9a0f789c17980aa577f8ca2b3b35832d3fL96-R123)
* [`ports/metrics/cbor_encoder.c`](diffhunk://#diff-f6804eaadb16fd9263d188b275c0eb3f62586d02e2e887b7e793decacfb4d066L26-L29): Removed the check for zero values in `metrics_encode_each` to align with the new set flag logic, ensuring only set metrics are encoded.