### PR TITLE
interface: uart: add configuration options for UART interface

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github:  [onkwon]

--- a/interfaces/uart/include/libmcu/uart.h
+++ b/interfaces/uart/include/libmcu/uart.h
@@ -18,13 +18,32 @@ struct uart;
 
 typedef void (*uart_rx_callback_t)(struct uart *self, void *ctx);
 
-struct uart_api {
-	int (*enable)(struct uart *self, uint32_t baudrate);
-	int (*disable)(struct uart *self);
-	int (*write)(struct uart *self, const void *data, size_t data_len);
-	int (*read)(struct uart *self, void *buf, size_t bufsize);
-	int (*register_rx_callback)(struct uart *self,
-			uart_rx_callback_t cb, void *cb_ctx);
+typedef enum {
+	UART_PARITY_NONE,
+	UART_PARITY_EVEN,
+	UART_PARITY_ODD,
+} uart_parity_t;
+
+typedef enum {
+	UART_STOPBIT_1,
+	UART_STOPBIT_2,
+	UART_STOPBIT_1_5,
+} uart_stopbit_t;
+
+typedef enum {
+	UART_FLOWCTRL_NONE,
+	UART_FLOWCTRL_RTS,
+	UART_FLOWCTRL_CTS,
+	UART_FLOWCTRL_CTS_RTS,
+} uart_flowctrl_t;
+
+struct uart_config {
+	uint32_t baudrate;
+	uint8_t databit;
+	uart_parity_t parity;
+	uart_stopbit_t stopbit;
+	uart_flowctrl_t flowctrl;
+	uint32_t rx_timeout_ms;
 };
 
 struct uart_pin {
@@ -34,31 +53,97 @@ struct uart_pin {
 	int cts;
 };
 
-static inline int uart_enable(struct uart *self, uint32_t baudrate) {
-	return ((struct uart_api *)self)->enable(self, baudrate);
-}
-
-static inline int uart_disable(struct uart *self) {
-	return ((struct uart_api *)self)->disable(self);
-}
-
-static inline int uart_write(struct uart *self,
-		const void *data, size_t data_len) {
-	return ((struct uart_api *)self)->write(self, data, data_len);
-}
-
-static inline int uart_read(struct uart *self, void *buf, size_t bufsize) {
-	return ((struct uart_api *)self)->read(self, buf, bufsize);
-}
-
-static inline int uart_register_rx_callback(struct uart *self,
-		uart_rx_callback_t cb, void *cb_ctx) {
-	return ((struct uart_api *)self)->register_rx_callback(self,
-			cb, cb_ctx);
-}
-
+/**
+ * @brief Create a UART instance.
+ *
+ * This function initializes a UART instance with the specified channel and pin
+ * configuration.
+ *
+ * @param[in] channel The UART channel number.
+ * @param[in] pin Pointer to the UART pin configuration structure.
+ * @return Pointer to the created UART instance, or NULL on failure.
+ */
 struct uart *uart_create(uint8_t channel, const struct uart_pin *pin);
+
+/**
+ * @brief Delete a UART instance.
+ *
+ * This function deinitializes and frees the resources associated with the
+ * specified UART instance.
+ *
+ * @param[in] self Pointer to the UART instance to be deleted.
+ */
 void uart_delete(struct uart *self);
+
+/**
+ * @brief Enable the UART interface.
+ *
+ * This function enables the UART interface with the specified baud rate.
+ *
+ * @param[in] self Pointer to the UART instance.
+ * @param[in] baudrate The baud rate for UART communication.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int uart_enable(struct uart *self, uint32_t baudrate);
+
+/**
+ * @brief Disable the UART interface.
+ *
+ * This function disables the UART interface.
+ *
+ * @param[in] self Pointer to the UART instance.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int uart_disable(struct uart *self);
+
+/**
+ * @brief Write data to the UART interface.
+ *
+ * This function writes the specified data to the UART interface.
+ *
+ * @param[in] self[] Pointer to the UART instance.
+ * @param[in] data Pointer to the data to be written.
+ * @param[in] data_len Length of the data to be written.
+ * @return Number of bytes written, or a negative error code on failure.
+ */
+int uart_write(struct uart *self, const void *data, size_t data_len);
+
+/**
+ * @brief Read data from the UART interface.
+ *
+ * This function reads data from the UART interface into the specified buffer.
+ *
+ * @param[in] self Pointer to the UART instance.
+ * @param[out] buf Pointer to the buffer to store the read data.
+ * @param[in] bufsize Size of the buffer.
+ * @return Number of bytes read, or a negative error code on failure.
+ */
+int uart_read(struct uart *self, void *buf, size_t bufsize);
+
+/**
+ * @brief Register a callback for UART receive events.
+ *
+ * This function registers a callback function to be called when data is
+ * received on the UART interface.
+ *
+ * @param[in] self Pointer to the UART instance.
+ * @param[in] cb Callback function to be called on receive events.
+ * @param[in] cb_ctx User-defined context to be passed to the callback function.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int uart_register_rx_callback(struct uart *self,
+		uart_rx_callback_t cb, void *cb_ctx);
+
+/**
+ * @brief Configure the UART interface.
+ *
+ * This function configures the UART interface with the specified settings.
+ *
+ * @param[in] self Pointer to the UART instance.
+ * @param[in] config Pointer to the UART configuration structure.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int uart_configure(struct uart *self, const struct uart_config *config);
 
 #if defined(__cplusplus)
 }

--- a/ports/esp-idf/uart.c
+++ b/ports/esp-idf/uart.c
@@ -4,27 +4,141 @@
  * SPDX-License-Identifier: MIT
  */
 
+#define UART_PARITY_EVEN	LIBMCU_UART_PARITY_EVEN
+#define UART_PARITY_ODD		LIBMCU_UART_PARITY_ODD
+#define uart_parity_t		libmcu_uart_parity_t
 #include "libmcu/uart.h"
+#undef uart_parity_t
+#undef UART_PARITY_ODD
+#undef UART_PARITY_EVEN
 
 #include <errno.h>
 #include <string.h>
 
 #include "driver/uart.h"
 
-#define MAX_UART		2
+#define MAX_UART			2
 
-#define DEFAULT_BUFSIZE		256
-#define DEFAULT_RXQUEUE_LEN	8
+#define DEFAULT_BUFSIZE			256
+#define DEFAULT_RXQUEUE_LEN		8
+
+#if !defined(UART_DEFAULT_OPTION_PARITY)
+#define UART_DEFAULT_OPTION_PARITY	UART_PARITY_NONE
+#endif
+#if !defined(UART_DEFAULT_OPTION_DATABIT)
+#define UART_DEFAULT_OPTION_DATABIT	8
+#endif
+#if !defined(UART_DEFAULT_OPTION_STOPBIT)
+#define UART_DEFAULT_OPTION_STOPBIT	UART_STOPBIT_1
+#endif
+#if !defined(UART_DEFAULT_OPTION_FLOWCTRL)
+#define UART_DEFAULT_OPTION_FLOWCTRL	UART_FLOWCTRL_NONE
+#endif
+#if !defined(UART_DEFAULT_OPTION_RX_TIMEOUT)
+#define UART_DEFAULT_OPTION_RX_TIMEOUT	-1
+#endif
 
 struct uart {
-	struct uart_api api;
+	struct uart_config config;
 	struct uart_pin pin;
 	uint8_t channel;
-	uint32_t baudrate;
 	bool activated;
 };
 
-static int write_uart(struct uart *self, const void *data, size_t data_len)
+static void set_config(uart_config_t *uart_config,
+		const struct uart_config *config)
+{
+	uart_config->baud_rate = config->baudrate;
+
+	switch (config->databit) {
+	case 5:
+		uart_config->data_bits = UART_DATA_5_BITS;
+		break;
+	case 6:
+		uart_config->data_bits = UART_DATA_6_BITS;
+		break;
+	case 7:
+		uart_config->data_bits = UART_DATA_7_BITS;
+		break;
+	case 8: /* fall through */
+	default:
+		uart_config->data_bits = UART_DATA_8_BITS;
+		break;
+	}
+
+	if (config->parity == LIBMCU_UART_PARITY_EVEN) {
+		uart_config->parity = UART_PARITY_EVEN;
+	} else if (config->parity == LIBMCU_UART_PARITY_ODD) {
+		uart_config->parity = UART_PARITY_ODD;
+	} else {
+		uart_config->parity = UART_PARITY_DISABLE;
+	}
+
+	if (config->stopbit == UART_STOPBIT_1_5) {
+		uart_config->stop_bits = UART_STOP_BITS_1_5;
+	} else if (config->stopbit == UART_STOPBIT_2) {
+		uart_config->stop_bits = UART_STOP_BITS_2;
+	} else {
+		uart_config->stop_bits = UART_STOP_BITS_1;
+	}
+
+	switch (config->flowctrl) {
+	case UART_FLOWCTRL_RTS:
+		uart_config->flow_ctrl = UART_HW_FLOWCTRL_RTS;
+		break;
+	case UART_FLOWCTRL_CTS:
+		uart_config->flow_ctrl = UART_HW_FLOWCTRL_CTS;
+		break;
+	case UART_FLOWCTRL_CTS_RTS:
+		uart_config->flow_ctrl = UART_HW_FLOWCTRL_CTS_RTS;
+		break;
+	case UART_FLOWCTRL_NONE: /* fall through */
+	default:
+		uart_config->flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
+		break;
+	}
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+	uart_config->source_clk = UART_SCLK_DEFAULT;
+#endif
+}
+
+static int update_config(struct uart *self)
+{
+	uart_config_t uart_config = { 0, };
+	set_config(&uart_config, &self->config);
+
+	if (uart_param_config(self->channel, &uart_config) != ESP_OK) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+int uart_configure(struct uart *self, const struct uart_config *config)
+{
+	if (!self) {
+		return -EPIPE;
+	} else if (!config) {
+		return -EINVAL;
+	}
+
+	const uint32_t baudrate = self->config.baudrate;
+
+	memcpy(&self->config, config, sizeof(*config));
+
+	if (self->config.baudrate == 0) {
+		self->config.baudrate = baudrate;
+	}
+
+	if (!self->activated) {
+		return 0;
+	}
+
+	return update_config(self);
+}
+
+int uart_write(struct uart *self, const void *data, size_t data_len)
 {
 	if (!self || !self->activated) {
 		return -EPIPE;
@@ -46,14 +160,14 @@ static int write_uart(struct uart *self, const void *data, size_t data_len)
 	return written;
 }
 
-static int read_uart(struct uart *self, void *buf, size_t bufsize)
+int uart_read(struct uart *self, void *buf, size_t bufsize)
 {
 	if (!self || !self->activated) {
 		return -EPIPE;
 	}
 
-	int len = uart_read_bytes(self->channel,
-			   buf, bufsize, (TickType_t)portMAX_DELAY);
+	int len = uart_read_bytes(self->channel, buf, bufsize,
+			pdMS_TO_TICKS(self->config.rx_timeout_ms));
 
 	if (len < 0) {
 		return -EIO;
@@ -62,7 +176,7 @@ static int read_uart(struct uart *self, void *buf, size_t bufsize)
 	return len;
 }
 
-static int enable_uart(struct uart *self, uint32_t baudrate)
+int uart_enable(struct uart *self, uint32_t baudrate)
 {
 	if (!self) {
 		return -EPIPE;
@@ -70,36 +184,25 @@ static int enable_uart(struct uart *self, uint32_t baudrate)
 		return -EALREADY;
 	}
 
-	uart_config_t uart_config = {
-		.baud_rate = baudrate,
-		.data_bits = UART_DATA_8_BITS,
-		.parity    = UART_PARITY_DISABLE,
-		.stop_bits = UART_STOP_BITS_1,
-		.flow_ctrl = UART_HW_FLOWCTRL_DISABLE,
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
-		.source_clk = UART_SCLK_DEFAULT,
-#endif
-	};
-
 	if (uart_driver_install(self->channel, DEFAULT_BUFSIZE*2,
 					DEFAULT_BUFSIZE*2, DEFAULT_RXQUEUE_LEN,
 					NULL, 0) != ESP_OK) {
 		return -EFAULT;
 	}
 
-	self->baudrate = baudrate;
 	self->activated = true;
+	self->config.baudrate = baudrate;
 
-	if (uart_param_config(self->channel, &uart_config) != ESP_OK ||
-			uart_set_pin(self->channel, self->pin.tx, self->pin.rx,
-				self->pin.rts, self->pin.cts) != ESP_OK) {
+	if (uart_set_pin(self->channel, self->pin.tx, self->pin.rx,
+				self->pin.rts, self->pin.cts) != ESP_OK ||
+			update_config(self) != 0) {
 		return -EINVAL;
 	}
 
 	return 0;
 }
 
-static int disable_uart(struct uart *self)
+int uart_disable(struct uart *self)
 {
 	if (!self) {
 		return -EPIPE;
@@ -124,14 +227,14 @@ struct uart *uart_create(uint8_t channel, const struct uart_pin *pin)
 		return NULL;
 	}
 
-	uart[channel].api = (struct uart_api) {
-		.enable = enable_uart,
-		.disable = disable_uart,
-		.write = write_uart,
-		.read = read_uart,
-	};
-
 	uart[channel].channel = channel;
+	uart[channel].config = (struct uart_config) {
+		.databit = UART_DEFAULT_OPTION_DATABIT,
+		.parity = UART_DEFAULT_OPTION_PARITY,
+		.stopbit = UART_DEFAULT_OPTION_STOPBIT,
+		.flowctrl = UART_DEFAULT_OPTION_FLOWCTRL,
+		.rx_timeout_ms = UART_DEFAULT_OPTION_RX_TIMEOUT,
+	};
 
 	if (pin) {
 		memcpy(&uart[channel].pin, pin, sizeof(*pin));


### PR DESCRIPTION
This pull request includes significant updates to the UART interface, focusing on enhancing its configuration capabilities and improving code clarity. The changes introduce new configuration options for UART settings and replace the old API structure with a more flexible and detailed configuration approach.

### Enhancements to UART configuration:

* Added new enumerations for UART parity, stop bits, and flow control options (`UART_PARITY_NONE`, `UART_PARITY_EVEN`, `UART_PARITY_ODD`, `UART_STOPBIT_1`, `UART_STOPBIT_2`, `UART_STOPBIT_1_5`, `UART_FLOWCTRL_NONE`, `UART_FLOWCTRL_RTS`, `UART_FLOWCTRL_CTS`, `UART_FLOWCTRL_CTS_RTS`). (`[interfaces/uart/include/libmcu/uart.hL21-R46](diffhunk://#diff-3980e42cb29e9fd538c989e0ddb53be939a7206af63fc0f65828450a4ecef673L21-R46)`)

* Introduced a new `uart_config` structure to encapsulate UART settings such as baud rate, data bits, parity, stop bits, flow control, and receive timeout. (`[interfaces/uart/include/libmcu/uart.hL21-R46](diffhunk://#diff-3980e42cb29e9fd538c989e0ddb53be939a7206af63fc0f65828450a4ecef673L21-R46)`)

### Code refactoring:

* Replaced the old `uart_api` structure with individual functions for creating, deleting, enabling, disabling, writing to, reading from, and configuring UART instances. This includes detailed documentation for each function. (`[interfaces/uart/include/libmcu/uart.hL37-R146](diffhunk://#diff-3980e42cb29e9fd538c989e0ddb53be939a7206af63fc0f65828450a4ecef673L37-R146)`)

* Updated the `uart.c` file to use the new `uart_config` structure for UART configuration, including setting default options and updating the configuration dynamically. (`[[1]](diffhunk://#diff-c81321e06ba433f9edb3b3451f0fe5738efe076acfa80609c5c7a30c93ca7f4aR25-R141)`, `[[2]](diffhunk://#diff-c81321e06ba433f9edb3b3451f0fe5738efe076acfa80609c5c7a30c93ca7f4aL49-R170)`, `[[3]](diffhunk://#diff-c81321e06ba433f9edb3b3451f0fe5738efe076acfa80609c5c7a30c93ca7f4aL65-R205)`, `[[4]](diffhunk://#diff-c81321e06ba433f9edb3b3451f0fe5738efe076acfa80609c5c7a30c93ca7f4aL127-R237)`)

### Codebase simplification:

* Removed the old inline functions for enabling, disabling, writing, reading, and registering callbacks with UART, replacing them with more explicit function definitions. (`[interfaces/uart/include/libmcu/uart.hL37-R146](diffhunk://#diff-3980e42cb29e9fd538c989e0ddb53be939a7206af63fc0f65828450a4ecef673L37-R146)`)

* Introduced macros to map the new UART parity definitions to existing library definitions and ensure compatibility. (`[ports/esp-idf/uart.cR7-R13](diffhunk://#diff-c81321e06ba433f9edb3b3451f0fe5738efe076acfa80609c5c7a30c93ca7f4aR7-R13)`)