### PR TITLE
Add xmodem protocol implementation

### DIFF
--- a/modules/common/include/libmcu/crc16.h
+++ b/modules/common/include/libmcu/crc16.h
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: 2018 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef LIBMCU_CRC16_H
+#define LIBMCU_CRC16_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <stddef.h>
+
+uint16_t crc16_update(uint16_t poly, uint16_t crc, uint8_t c);
+
+uint16_t crc16_modbus(const void *data, size_t datasize);
+uint16_t crc16_xmodem(const void *data, size_t datasize);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* LIBMCU_CRC16_H */

--- a/modules/common/include/libmcu/crc16.h
+++ b/modules/common/include/libmcu/crc16.h
@@ -15,9 +15,7 @@ extern "C" {
 #include <stddef.h>
 
 uint16_t crc16_update(uint16_t poly, uint16_t crc, uint8_t c);
-
 uint16_t crc16_modbus(const void *data, size_t datasize);
-uint16_t crc16_xmodem(const void *data, size_t datasize);
 
 #if defined(__cplusplus)
 }

--- a/modules/common/include/libmcu/xmodem.h
+++ b/modules/common/include/libmcu/xmodem.h
@@ -1,0 +1,126 @@
+/*
+ * SPDX-FileCopyrightText: 2018 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef LIBMCU_XMODEM_H
+#define LIBMCU_XMODEM_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef enum {
+	XMODEM_ERROR_NONE,
+	XMODEM_ERROR,
+	XMODEM_ERROR_INVALID_PARAM,
+	XMODEM_ERROR_NO_ENOUGH_BUFFER,
+	XMODEM_ERROR_TIMEOUT,
+	XMODEM_ERROR_NO_RESPONSE,
+	XMODEM_ERROR_NO_INPUT,
+	XMODEM_ERROR_CANCELED,
+	XMODEM_ERROR_CANCELED_BY_REMOTE,
+	XMODEM_ERROR_CRC_MISMATCH,
+	XMODEM_ERROR_INCORRECT_SEQ,
+	XMODEM_ERROR_RETRY,
+	XMODEM_ERROR_RECEIVING,
+} xmodem_error_t;
+
+typedef enum {
+	XMODEM_DATA_BLOCK_128, /* NAK. DLE '6' C' */
+	XMODEM_DATA_BLOCK_128_CRC,
+	XMODEM_DATA_BLOCK_1K,  /* 'C'. DLE '4' C' */
+} xmodem_data_block_size_t;
+
+/**
+ * @brief Callback function for receiving XMODEM packets.
+ *
+ * The callback function that will be called when an XMODEM packet is received.
+ *
+ * @note seq will be 0 for the last packet of EOT.
+ *
+ * @param[in] seq The sequence number of the received packet.
+ * @param[in] data The pointer to the data of the received packet.
+ * @param[in] datasize The size of the received data.
+ * @param[in] ctx The context passed to the callback function.
+ *
+ * @return The error status of the receive operation.
+ */
+typedef xmodem_error_t (*xmodem_recv_callback_t)(size_t seq,
+		const uint8_t *data, size_t datasize, void *ctx);
+
+typedef int (*xmodem_reader_t)(uint8_t *buf, size_t bufsize,
+		uint32_t timeout_ms);
+typedef int (*xmodem_writer_t)(const uint8_t *data, size_t datasize,
+		uint32_t timeout_ms);
+
+typedef uint32_t (*xmodem_millis_t)(void);
+
+/**
+ * @brief Sets the I/O functions for XMODEM protocol.
+ *
+ * This function sets the reader and writer functions that will be used
+ * by the XMODEM protocol for reading from and writing to the communication
+ * medium.
+ *
+ * @param[in] reader The function pointer to the reader function.
+ * @param[in] writer The function pointer to the writer function.
+ */
+void xmodem_set_io(xmodem_reader_t reader, xmodem_writer_t writer);
+
+/**
+ * @brief Sets the receive buffer for the XMODEM protocol.
+ *
+ * This function sets the buffer that will be used to store incoming data
+ * packets received via the XMODEM protocol.
+ *
+ * @note The buffer must be set before calling xmodem_receive(). The buffer must
+ * be large enough to store the incoming data packets. At least 128 bytes for
+ * 128-byte data or 1024 bytes for 1KB data should be provided. The buffer is
+ * the one passed to the callback function.
+ *
+ * @param[out] rx_buf The buffer to store received data.
+ * @param[in] rx_bufsize The size of the receive buffer.
+ */
+void xmodem_set_rx_buffer(uint8_t *rx_buf, size_t rx_bufsize);
+
+/**
+ * @brief Sets the function to get the current time in milliseconds.
+ *
+ * This function sets the function pointer that will be used to get the
+ * current time in milliseconds. This is used by the XMODEM protocol for
+ * timing operations.
+ *
+ * @param[in] millis The function pointer to the function that returns the current
+ *                   time in milliseconds.
+ */
+void xmodem_set_millis(xmodem_millis_t millis);
+
+/**
+ * @brief Receives data using the XMODEM protocol.
+ *
+ * This function receives data packets using the XMODEM protocol with the
+ * specified block size and timeout. It also calls a callback function when a
+ * packet is received.
+ *
+ * @param[in] block_type The size of the data block to be received.
+ * @param[in] on_recv The callback function to be called when a packet is
+ *                    received.
+ * @param[in] on_recv_ctx The context to be passed to the callback function.
+ * @param[in] timeout_ms The timeout in milliseconds for the receive operation.
+ *
+ * @return The error status of the receive operation.
+ */
+xmodem_error_t xmodem_receive(xmodem_data_block_size_t block_type,
+		xmodem_recv_callback_t on_recv, void *on_recv_ctx,
+		uint32_t timeout_ms);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* LIBMCU_XMODEM_H */

--- a/modules/common/include/libmcu/xmodem.h
+++ b/modules/common/include/libmcu/xmodem.h
@@ -57,20 +57,42 @@ typedef int (*xmodem_reader_t)(uint8_t *buf, size_t bufsize,
 		uint32_t timeout_ms);
 typedef int (*xmodem_writer_t)(const uint8_t *data, size_t datasize,
 		uint32_t timeout_ms);
+typedef void (*xmodem_flush_t)(void);
 
 typedef uint32_t (*xmodem_millis_t)(void);
 
 /**
- * @brief Sets the I/O functions for XMODEM protocol.
+ * @brief Receives data using the XMODEM protocol.
  *
- * This function sets the reader and writer functions that will be used
- * by the XMODEM protocol for reading from and writing to the communication
- * medium.
+ * This function receives data packets using the XMODEM protocol with the
+ * specified block size and timeout. It also calls a callback function when a
+ * packet is received.
  *
- * @param[in] reader The function pointer to the reader function.
- * @param[in] writer The function pointer to the writer function.
+ * @param[in] block_type The size of the data block to be received.
+ * @param[in] on_recv The callback function to be called when a packet is
+ *                    received.
+ * @param[in] on_recv_ctx The context to be passed to the callback function.
+ * @param[in] timeout_ms The timeout in milliseconds for the receive operation.
+ *
+ * @return The error status of the receive operation.
  */
-void xmodem_set_io(xmodem_reader_t reader, xmodem_writer_t writer);
+xmodem_error_t xmodem_receive(xmodem_data_block_size_t block_type,
+		xmodem_recv_callback_t on_recv, void *on_recv_ctx,
+		uint32_t timeout_ms);
+
+/**
+ * @brief Set the I/O functions for XMODEM communication.
+ *
+ * This function sets the reader, writer, and flush functions to be used for
+ * XMODEM communication. These functions are used to read from, write to, and
+ * flush the communication interface, respectively.
+ *
+ * @param[in] reader The function to read data from the communication interface.
+ * @param[in] writer The function to write data to the communication interface.
+ * @param[in] flush The function to flush the communication interface.
+ */
+void xmodem_set_io(xmodem_reader_t reader, xmodem_writer_t writer,
+		xmodem_flush_t flush);
 
 /**
  * @brief Sets the receive buffer for the XMODEM protocol.
@@ -98,26 +120,7 @@ void xmodem_set_rx_buffer(uint8_t *rx_buf, size_t rx_bufsize);
  * @param[in] millis The function pointer to the function that returns the current
  *                   time in milliseconds.
  */
-void xmodem_set_millis(xmodem_millis_t millis);
-
-/**
- * @brief Receives data using the XMODEM protocol.
- *
- * This function receives data packets using the XMODEM protocol with the
- * specified block size and timeout. It also calls a callback function when a
- * packet is received.
- *
- * @param[in] block_type The size of the data block to be received.
- * @param[in] on_recv The callback function to be called when a packet is
- *                    received.
- * @param[in] on_recv_ctx The context to be passed to the callback function.
- * @param[in] timeout_ms The timeout in milliseconds for the receive operation.
- *
- * @return The error status of the receive operation.
- */
-xmodem_error_t xmodem_receive(xmodem_data_block_size_t block_type,
-		xmodem_recv_callback_t on_recv, void *on_recv_ctx,
-		uint32_t timeout_ms);
+void xmodem_set_millis(xmodem_millis_t fn);
 
 #if defined(__cplusplus)
 }

--- a/modules/common/src/crc16.c
+++ b/modules/common/src/crc16.c
@@ -37,15 +37,3 @@ uint16_t crc16_modbus(const void *data, size_t datasize)
 
 	return crc;
 }
-
-uint16_t crc16_xmodem(const void *data, size_t datasize)
-{
-	const uint8_t *p = (const uint8_t *)data;
-	uint16_t crc = 0;
-
-	for (size_t i = 0; i < datasize; i++) {
-		crc = update(0x1021, crc, p[i]);
-	}
-
-	return crc;
-}

--- a/modules/common/src/crc16.c
+++ b/modules/common/src/crc16.c
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: 2018 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "libmcu/crc16.h"
+
+static uint16_t update(uint16_t poly, uint16_t crc, uint8_t c)
+{
+	crc = (uint16_t)(crc ^ c);
+
+	for (int i = 0; i < 8; i++) {
+		if (crc & 1u) {
+			crc = (crc >> 1) ^ poly;
+		} else {
+			crc = (crc >> 1);
+		}
+	}
+
+	return crc;
+}
+
+uint16_t crc16_update(uint16_t poly, uint16_t crc, uint8_t c)
+{
+	return update(poly, crc, c);
+}
+
+uint16_t crc16_modbus(const void *data, size_t datasize)
+{
+	const uint8_t *p = (const uint8_t *)data;
+	uint16_t crc = 0xFFFFu;
+
+	for (size_t i = 0; i < datasize; i++) {
+		crc = update(0xA001, crc, p[i]);
+	}
+
+	return crc;
+}
+
+uint16_t crc16_xmodem(const void *data, size_t datasize)
+{
+	const uint8_t *p = (const uint8_t *)data;
+	uint16_t crc = 0;
+
+	for (size_t i = 0; i < datasize; i++) {
+		crc = update(0x1021, crc, p[i]);
+	}
+
+	return crc;
+}

--- a/modules/common/src/xmodem.c
+++ b/modules/common/src/xmodem.c
@@ -1,0 +1,333 @@
+/*
+ * SPDX-FileCopyrightText: 2018 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "libmcu/xmodem.h"
+#include "libmcu/crc16.h"
+#include <errno.h>
+#include <stdbool.h>
+
+#define META_SIZE		4
+
+#define DATA_SIZE_128		128
+#define DATA_SIZE_1K		1024
+#define DEFAULT_DATA_SIZE	DATA_SIZE_128
+
+#define TIMEOUT_SYNC_SEC	60
+#define TIMEOUT_ACK_SEC		10
+#define TIMEOUT_ONE_CHAR_SEC	1
+#define TIMEOUT_INIT_SEC	3
+
+#define IO_TIMEOUT		(TIMEOUT_ONE_CHAR_SEC * 1000)
+
+#if !defined(MIN)
+#define MIN(a, b)		((a) < (b)? (a) : (b))
+#endif
+
+enum {
+	SOH			= 0x01,
+	STX			= 0x02,
+	ETX			= 0x03,
+	EOT			= 0x04,
+	ACK			= 0x06,
+	DLE			= 0x10,
+	NAK			= 0x15,
+	CAN			= 0x18,
+	SUB			= 0x1A,
+	IDL			= 0x43, /* 'C' */
+};
+
+struct packet {
+	uint8_t header;
+	uint8_t seq;
+	uint8_t seq_inverted;
+	uint8_t *data;
+	uint8_t chksum[2];
+
+	size_t received;
+	uint8_t seq_expected;
+};
+
+static struct {
+	xmodem_reader_t reader;
+	xmodem_writer_t writer;
+
+	xmodem_millis_t millis;
+
+	uint8_t *buf;
+	size_t bufsize;
+} m;
+
+static uint32_t millis(void)
+{
+	if (m.millis == NULL) {
+		return 0;
+	}
+
+	return m.millis();
+}
+
+static int do_send(const uint8_t *data, size_t datasize, uint32_t timeout_ms)
+{
+	if (m.writer == NULL) {
+		return -ENODEV;
+	}
+
+	return m.writer(data, datasize, timeout_ms);
+}
+
+static int do_read(uint8_t *buf, size_t bufsize, uint32_t timeout_ms)
+{
+	if (m.reader == NULL) {
+		return -ENODEV;
+	}
+
+	return m.reader(buf, bufsize, timeout_ms);
+}
+
+static int read_byte(uint8_t *ch)
+{
+	return do_read(ch, 1, IO_TIMEOUT);
+}
+
+static int send_can(void)
+{
+	uint8_t tx[] = { CAN, CAN };
+	return do_send(tx, sizeof(tx), IO_TIMEOUT);
+}
+
+static int send_nak(void)
+{
+	uint8_t tx = NAK;
+	return do_send(&tx, sizeof(tx), IO_TIMEOUT);
+}
+
+static int send_ack(void)
+{
+	uint8_t tx = ACK;
+	return do_send(&tx, sizeof(tx), IO_TIMEOUT);
+}
+
+static bool is_timedout(uint32_t now, uint32_t start, uint32_t timeout)
+{
+	return (now - start) >= timeout;
+}
+
+static bool is_last_packet(const struct packet *packet)
+{
+	return packet->header == EOT || packet->header == CAN;
+}
+
+static bool sync_sender(struct packet *packet,
+		uint8_t *initiator, uint32_t timeout_ms)
+{
+	const uint32_t t_started = millis();
+	uint32_t t_now = t_started;
+	uint32_t t_sent = t_started - TIMEOUT_ONE_CHAR_SEC * 1000;
+	size_t count = 0;
+
+	do {
+		if (is_timedout(t_now, t_sent, TIMEOUT_ONE_CHAR_SEC * 1000)) {
+			if (*initiator == IDL && count >
+					(TIMEOUT_ACK_SEC / TIMEOUT_INIT_SEC)) {
+				*initiator = NAK;
+			}
+			do_send(initiator, 1, IO_TIMEOUT);
+			t_sent = t_now;
+			count += 1;
+		}
+
+		if (read_byte(&packet->header) == 1) {
+			packet->received = 1;
+			return true;
+		}
+
+		t_now = millis();
+	} while (!is_timedout(t_now, t_started, timeout_ms));
+
+	return false;
+}
+
+static bool is_packet_valid(const struct packet *packet, bool crc)
+{
+	const size_t data_size = packet->received - META_SIZE - (crc? 1 : 0);
+
+	if (packet->header == EOT || packet->header == CAN) {
+		return true;
+	} else if (packet->received < META_SIZE + (crc? 1 : 0)) {
+		return false;
+	}
+
+	if (crc) {
+		uint16_t c = crc16_xmodem(packet->data, data_size);
+		return c == (packet->chksum[0] << 8 | packet->chksum[1]);
+	}
+
+	uint8_t chksum = 0;
+
+	for (size_t i = 0; i < data_size; i++) {
+		chksum += packet->data[i];
+	}
+
+	return chksum == packet->chksum[0];
+}
+
+static void fill_buffer(struct packet *packet,
+		uint8_t ch, size_t index, size_t data_size)
+{
+	if (index < 3) { /* header */
+		uint8_t *p = (uint8_t *)packet;
+		p[index] = ch;
+	} else if (index >= 3 && (index - 3) < data_size) { /* data */
+		packet->data[index - 3] = ch;
+	} else if ((index - 3) >= data_size) { /* checksum */
+		packet->chksum[index - 3 - data_size] = ch;
+	}
+}
+
+static xmodem_error_t check_buffer(const struct packet *packet, size_t index)
+{
+	if (index == 0) {
+		if (packet->header == EOT) {
+			return XMODEM_ERROR_NONE;
+		} else if (packet->header == CAN) {
+			return XMODEM_ERROR_CANCELED_BY_REMOTE;
+		} else if (packet->header != SOH && packet->header != STX) {
+			return XMODEM_ERROR_RETRY;
+		}
+	} else if (index == 2) {
+		if ((uint8_t)~packet->seq != (uint8_t)packet->seq_inverted) {
+			return XMODEM_ERROR_RETRY;
+		}
+	}
+	return XMODEM_ERROR_RECEIVING;
+}
+
+static xmodem_error_t read_packet(struct packet *packet,
+		size_t data_size, bool crc, uint32_t timeout_ms)
+{
+	const uint32_t t_started = millis();
+	size_t *index = (size_t *)&packet->received;
+	xmodem_error_t err = XMODEM_ERROR_TIMEOUT;
+	uint32_t t_read = t_started;
+	uint32_t t_now;
+	uint8_t ch;
+
+	if (*index == 1 && packet->header != SOH && packet->header != STX) {
+		*index = 0;
+	}
+
+	do {
+		t_now = millis();
+
+		if (read_byte(&ch) != 1) {
+			if (is_timedout(t_now, t_read,
+					TIMEOUT_ONE_CHAR_SEC * 1000)) {
+				send_nak();
+				return XMODEM_ERROR_NO_INPUT;
+			}
+			continue;
+		}
+
+		t_read = t_now;
+		fill_buffer(packet, ch, *index, data_size);
+		err = check_buffer(packet, *index);
+
+		if (err == XMODEM_ERROR_RETRY) {
+			continue;
+		} else if (err == XMODEM_ERROR_RECEIVING) {
+			*index = *index + 1;
+			if (*index >= (META_SIZE + data_size + (crc? 1 : 0))) {
+				return XMODEM_ERROR_NONE;
+			}
+		} else {
+			return err;
+		}
+	} while (!is_timedout(t_now, t_started, timeout_ms));
+
+	return err;
+}
+
+xmodem_error_t xmodem_receive(xmodem_data_block_size_t block_type,
+		xmodem_recv_callback_t on_recv, void *on_recv_ctx,
+		uint32_t timeout_ms)
+{
+	const uint32_t t_started = millis();
+	struct packet packet = { .data = m.buf, .seq_expected = 1};
+	size_t data_size = DEFAULT_DATA_SIZE;
+	size_t nr_packets = 0;
+	uint8_t initiator = block_type == XMODEM_DATA_BLOCK_128? NAK : IDL;
+	uint32_t t_now;
+	xmodem_error_t err;
+
+	if (packet.data == NULL) {
+		return XMODEM_ERROR_INVALID_PARAM;
+	}
+
+	if (!sync_sender(&packet,
+			&initiator, MIN(timeout_ms, TIMEOUT_SYNC_SEC*1000))) {
+		return XMODEM_ERROR_NO_RESPONSE;
+	}
+
+	if (initiator == IDL && block_type == XMODEM_DATA_BLOCK_1K) {
+		data_size = DATA_SIZE_1K;
+	}
+
+	if (data_size > m.bufsize) {
+		return XMODEM_ERROR_NO_ENOUGH_BUFFER;
+	}
+
+	do {
+		t_now = millis();
+		err = read_packet(&packet, data_size, initiator == IDL,
+				TIMEOUT_ACK_SEC * 1000);
+
+		if (err == XMODEM_ERROR_NONE &&
+				is_packet_valid(&packet, initiator == IDL)) {
+			if (packet.seq == packet.seq_expected) {
+				packet.seq_expected = (uint8_t)
+					((packet.seq + 1) % 256);
+				nr_packets += 1;
+				if (on_recv) {
+					(*on_recv)(packet.header == EOT?
+							0 : nr_packets,
+							packet.data, data_size,
+							on_recv_ctx);
+				}
+			}
+			packet.received = 0;
+			send_ack();
+			continue;
+		}
+
+		packet.received = 0;
+		send_nak();
+	} while (!is_timedout(t_now, t_started, timeout_ms) &&
+			!is_last_packet(&packet));
+
+	if (!is_last_packet(&packet)) {
+		send_can();
+		err = err == XMODEM_ERROR_NONE? XMODEM_ERROR_TIMEOUT : err;
+	}
+
+	return err;
+}
+
+void xmodem_set_io(xmodem_reader_t reader, xmodem_writer_t writer)
+{
+	m.reader = reader;
+	m.writer = writer;
+}
+
+void xmodem_set_rx_buffer(uint8_t *rx_buf, size_t rx_bufsize)
+{
+	m.buf = rx_buf;
+	m.bufsize = rx_bufsize;
+}
+
+void xmodem_set_millis(xmodem_millis_t millis)
+{
+	m.millis = millis;
+}

--- a/tests/runners/common/xmodem.mk
+++ b/tests/runners/common/xmodem.mk
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+
+COMPONENT_NAME = XMODEM
+
+SRC_FILES = \
+	../modules/common/src/xmodem.c \
+	../modules/common/src/crc16.c \
+
+TEST_SRC_FILES = \
+	src/common/xmodem_test.cpp \
+	src/test_all.cpp \
+
+INCLUDE_DIRS = \
+	../modules/common/include \
+	$(CPPUTEST_HOME)/include \
+
+MOCKS_SRC_DIRS =
+CPPUTEST_CPPFLAGS =
+
+include runners/MakefileRunner

--- a/tests/src/common/xmodem_test.cpp
+++ b/tests/src/common/xmodem_test.cpp
@@ -35,7 +35,7 @@ TEST_GROUP(XMODEM) {
 	uint8_t buf[1024];
 
 	void setup(void) {
-		xmodem_set_io(xmodem_read, xmodem_write);
+		xmodem_set_io(xmodem_read, xmodem_write, NULL);
 		xmodem_set_millis(millis);
 		xmodem_set_rx_buffer(buf, sizeof(buf));
 	}
@@ -65,47 +65,62 @@ TEST_GROUP(XMODEM) {
 			.withParameter("timeout_ms", 1000);
 	}
 
-	void expect_packet(const char stx[1], const char seq[1],
-			const char seq_inv[1],
-			const char chksum[1], size_t data_count) {
-		mock().expectNCalls(3, "millis").andReturnValue(0);
-		mock().expectOneCall("xmodem_read")
-			.withOutputParameterReturning("buf", (const uint8_t *)stx, 1)
-			.ignoreOtherParameters()
-			.andReturnValue(1);
-
-		mock().expectOneCall("millis").andReturnValue(0);
+	void expect_packet_without_stx(const char seq[1], const char seq_inv[1],
+			const char chksum[1], size_t data_count, uint32_t t = 0) {
+		mock().expectOneCall("millis").andReturnValue(t);
 		mock().expectOneCall("xmodem_read")
 			.withOutputParameterReturning("buf", (const uint8_t *)seq, 1)
 			.ignoreOtherParameters()
 			.andReturnValue(1);
-		mock().expectOneCall("millis").andReturnValue(0);
+		mock().expectOneCall("millis").andReturnValue(t);
 		mock().expectOneCall("xmodem_read")
 			.withOutputParameterReturning("buf", (const uint8_t *)seq_inv, 1)
 			.ignoreOtherParameters()
 			.andReturnValue(1);
 
 		for (size_t i = 0; i < data_count; i++) {
-			mock().expectOneCall("millis").andReturnValue(0);
+			mock().expectOneCall("millis").andReturnValue(t);
 			mock().expectOneCall("xmodem_read")
 				.withOutputParameterReturning("buf", (const uint8_t *)"\x00", 1)
 				.ignoreOtherParameters()
 				.andReturnValue(1);
 		}
 
-		mock().expectOneCall("millis").andReturnValue(0);
+		mock().expectOneCall("millis").andReturnValue(t);
 		mock().expectOneCall("xmodem_read")
 			.withOutputParameterReturning("buf", (const uint8_t *)chksum, 1)
 			.ignoreOtherParameters()
 			.andReturnValue(1);
 	}
 
-	void expect_packet_crc(const char stx[1], const char seq[1],
+	void expect_packet(const char stx[1], const char seq[1],
 			const char seq_inv[1],
+			const char chksum[1], size_t data_count, uint32_t t = 0) {
+		mock().expectNCalls(3, "millis").andReturnValue(t);
+		mock().expectOneCall("xmodem_read")
+			.withOutputParameterReturning("buf", (const uint8_t *)stx, 1)
+			.ignoreOtherParameters()
+			.andReturnValue(1);
+		expect_packet_without_stx(seq, seq_inv, chksum, data_count, t);
+	}
+
+	void expect_packet_crc(const char stx[1], const char seq[1], const char seq_inv[1],
 			const char crc1[1], const char crc2[1],
-			size_t data_count) {
-		expect_packet(stx, seq, seq_inv, crc1, data_count);
-		mock().expectOneCall("millis").andReturnValue(0);
+			size_t data_count, uint32_t t = 0) {
+		expect_packet(stx, seq, seq_inv, crc1, data_count, t);
+		mock().expectOneCall("millis").andReturnValue(t);
+		mock().expectOneCall("xmodem_read")
+			.withOutputParameterReturning("buf", (const uint8_t *)crc2, 1)
+			.ignoreOtherParameters()
+			.andReturnValue(1);
+	}
+
+	void expect_packet_crc_without_stx(const char seq[1], const char seq_inv[1],
+			const char crc1[1], const char crc2[1],
+			size_t data_count, uint32_t t = 0) {
+		mock().expectNCalls(2, "millis").andReturnValue(t);
+		expect_packet_without_stx(seq, seq_inv, crc1, data_count, t);
+		mock().expectOneCall("millis").andReturnValue(t);
 		mock().expectOneCall("xmodem_read")
 			.withOutputParameterReturning("buf", (const uint8_t *)crc2, 1)
 			.ignoreOtherParameters()
@@ -118,8 +133,34 @@ TEST_GROUP(XMODEM) {
 			.withParameter("timeout_ms", 1000);
 	}
 
-	void expect_eot(void) {
-		mock().expectNCalls(2, "millis").andReturnValue(0);
+	void expect_nak(void) {
+		mock().expectOneCall("xmodem_write")
+			.withMemoryBufferParameter("data", (const uint8_t *)"\x15", 1)
+			.withParameter("timeout_ms", 1000);
+	}
+
+	void expect_c(void) {
+		mock().expectOneCall("xmodem_write")
+			.withMemoryBufferParameter("data", (const uint8_t *)"\x43", 1)
+			.withParameter("timeout_ms", 1000);
+	}
+
+	void expect_stx(const char stx[1]) {
+		mock().expectOneCall("xmodem_read")
+			.withOutputParameterReturning("buf", (const uint8_t *)stx, 1)
+			.ignoreOtherParameters()
+			.andReturnValue(1);
+	}
+
+	void expect_remote_cancel(void) {
+		mock().expectOneCall("xmodem_read")
+			.withOutputParameterReturning("buf", (const uint8_t *)"\x18", 1)
+			.ignoreOtherParameters()
+			.andReturnValue(1);
+	}
+
+	void expect_eot(uint32_t t = 0) {
+		mock().expectNCalls(3, "millis").andReturnValue(t);
 		mock().expectOneCall("xmodem_read")
 			.withOutputParameterReturning("buf", (const uint8_t *)"\x04", 1)
 			.ignoreOtherParameters()
@@ -135,28 +176,28 @@ TEST(XMODEM, ShouldReceiverSendNAK_WhenNotCRCSupported) {
 			xmodem_receive(XMODEM_DATA_BLOCK_128, 0, 0, 10000));
 }
 
-TEST(XMODEM, ShouldReceiverSendNAK_WhenNoResponseFromSenderWithC) {
+TEST(XMODEM, ShouldReceiverSendC_WhenCRCSupported) {
 	mock().expectNCalls(2, "millis").andReturnValue(0);
-	expect_sync_with_no_response(0, 1000, 4, (const uint8_t[]){ 'C' }, 1);
-	expect_sync_with_no_response(4000, 1000, 2, (const uint8_t[]){ 0x15 }, 1);
+	expect_sync_with_no_response(0, 1000, 10, (const uint8_t[]){ 'C' }, 1);
 
 	LONGS_EQUAL(XMODEM_ERROR_NO_RESPONSE,
-			xmodem_receive(XMODEM_DATA_BLOCK_128_CRC, 0, 0, 6000));
+			xmodem_receive(XMODEM_DATA_BLOCK_128_CRC, 0, 0, 10000));
 }
 
-TEST(XMODEM, ShouldReceiverSendNAKAfterC_When1KBlockRequestedAndNoResponse) {
+TEST(XMODEM, ShouldReceiverSendC_When1KCRCSupported) {
 	mock().expectNCalls(2, "millis").andReturnValue(0);
-	expect_sync_with_no_response(0, 1000, 4, (const uint8_t[]){ 'C' }, 1);
-	expect_sync_with_no_response(4000, 1000, 2, (const uint8_t[]){ 0x15 }, 1);
+	expect_sync_with_no_response(0, 1000, 10, (const uint8_t[]){ 'C' }, 1);
 
 	LONGS_EQUAL(XMODEM_ERROR_NO_RESPONSE,
-			xmodem_receive(XMODEM_DATA_BLOCK_1K, 0, 0, 6000));
+			xmodem_receive(XMODEM_DATA_BLOCK_1K, 0, 0, 10000));
 }
 
 TEST(XMODEM, ShouldReceivePacketSuccessfully_WhenValidPacketReceived) {
 	expect_sync("\x15");
+	expect_stx("\x01");
 
-	expect_packet("\x01", "\x01", "\xFE", "\x00", 128);
+	mock().expectNCalls(2, "millis").andReturnValue(0);
+	expect_packet_without_stx("\x01", "\xFE", "\x00", 128);
 	expect_ack();
 
 	expect_eot();
@@ -168,22 +209,69 @@ TEST(XMODEM, ShouldReceivePacketSuccessfully_WhenValidPacketReceived) {
 
 TEST(XMODEM, ShouldReceivePacketWith16bitCRC_WhenValidPacketReceived) {
 	expect_sync("\x43");
-
-	expect_packet_crc("\x01", "\x01", "\xFE", "\x00", "\x00", 128);
+	expect_stx("\x01");
+	expect_packet_crc_without_stx("\x01", "\xFE", "\x00", "\x00", 128);
 	expect_ack();
-
 	expect_eot();
 	expect_ack();
 	LONGS_EQUAL(XMODEM_ERROR_NONE,
 			xmodem_receive(XMODEM_DATA_BLOCK_128_CRC, 0, 0, 10000));
 
 	expect_sync("\x43");
-
-	expect_packet_crc("\x01", "\x01", "\xFE", "\x00", "\x00", 1024);
+	expect_stx("\x01");
+	expect_packet_crc_without_stx("\x01", "\xFE", "\x00", "\x00", 1024);
 	expect_ack();
-
 	expect_eot();
 	expect_ack();
 	LONGS_EQUAL(XMODEM_ERROR_NONE,
 			xmodem_receive(XMODEM_DATA_BLOCK_1K, 0, 0, 10000));
+}
+
+TEST(XMODEM, ShouldSendNAK_WhenNoCharacterReceivedForOneSecond) {
+	expect_sync("\x43");
+	expect_stx("\x01");
+	mock().expectNCalls(2, "millis").andReturnValue(0);
+	mock().expectOneCall("millis").andReturnValue(1000);
+	mock().expectOneCall("xmodem_read")
+		.ignoreOtherParameters()
+		.andReturnValue(0);
+	expect_nak();
+
+	expect_packet_crc("\x01", "\x01", "\xFE", "\x00", "\x00", 128, 1000);
+	expect_ack();
+
+	expect_eot(1000);
+	expect_ack();
+
+	LONGS_EQUAL(XMODEM_ERROR_NONE,
+	     xmodem_receive(XMODEM_DATA_BLOCK_128_CRC, 0, 0, 10000));
+}
+
+TEST(XMODEM, ShouldReturnInvalidParam_WhenBufferIsNull) {
+	mock().expectOneCall("millis").andReturnValue(0);
+	xmodem_set_rx_buffer(NULL, 0);
+	LONGS_EQUAL(XMODEM_ERROR_INVALID_PARAM,
+			xmodem_receive(XMODEM_DATA_BLOCK_128, 0, 0, 10000));
+}
+
+TEST(XMODEM, ShouldReturnNoEnoughBuffer_WhenBufferIsTooSmall) {
+	uint8_t buf[16];
+	mock().expectOneCall("millis").andReturnValue(0);
+	xmodem_set_rx_buffer(buf, sizeof(buf));
+	LONGS_EQUAL(XMODEM_ERROR_NO_ENOUGH_BUFFER,
+			xmodem_receive(XMODEM_DATA_BLOCK_128, 0, 0, 10000));
+}
+
+TEST(XMODEM, ShouldReturnCaneledByRemote_WhenRemoteSendCAN) {
+	expect_sync("\x15");
+	expect_stx("\x01");
+
+	mock().expectNCalls(2, "millis").andReturnValue(0);
+	expect_packet_without_stx("\x01", "\xFE", "\x00", 128);
+	expect_ack();
+
+	mock().expectNCalls(3, "millis").andReturnValue(0);
+	expect_remote_cancel();
+	LONGS_EQUAL(XMODEM_ERROR_CANCELED_BY_REMOTE,
+			xmodem_receive(XMODEM_DATA_BLOCK_128, 0, 0, 10000));
 }

--- a/tests/src/common/xmodem_test.cpp
+++ b/tests/src/common/xmodem_test.cpp
@@ -1,0 +1,189 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "CppUTest/TestHarness.h"
+#include "CppUTest/TestHarness_c.h"
+#include "CppUTestExt/MockSupport.h"
+
+#include "libmcu/xmodem.h"
+
+static int xmodem_read(uint8_t *buf, size_t bufsize, uint32_t timeout_ms) {
+	return mock().actualCall(__func__)
+		.withOutputParameter("buf", buf)
+		.withParameter("bufsize", bufsize)
+		.withParameter("timeout_ms", timeout_ms)
+		.returnIntValueOrDefault(0);
+}
+
+static int xmodem_write(const uint8_t *data, size_t datasize,
+		uint32_t timeout_ms) {
+	return mock().actualCall(__func__)
+		.withMemoryBufferParameter("data", data, datasize)
+		.withParameter("timeout_ms", timeout_ms)
+		.returnIntValueOrDefault(0);
+}
+
+static uint32_t millis(void) {
+	return mock().actualCall(__func__)
+		.returnUnsignedIntValueOrDefault(0);
+}
+
+TEST_GROUP(XMODEM) {
+	uint8_t buf[1024];
+
+	void setup(void) {
+		xmodem_set_io(xmodem_read, xmodem_write);
+		xmodem_set_millis(millis);
+		xmodem_set_rx_buffer(buf, sizeof(buf));
+	}
+	void teardown(void) {
+		mock().checkExpectations();
+		mock().clear();
+	}
+
+	void expect_sync_with_no_response(uint32_t start_ms, uint32_t step_ms,
+			uint32_t count, const uint8_t *data, size_t datasize) {
+		for (uint32_t i = 0; i < count; i++) {
+			const uint32_t t = start_ms + step_ms * (i+1);
+			mock().expectOneCall("xmodem_write")
+				.withMemoryBufferParameter("data", data, datasize)
+				.withParameter("timeout_ms", 1000);
+			mock().expectOneCall("xmodem_read")
+				.ignoreOtherParameters()
+				.andReturnValue(0);
+			mock().expectNCalls(1, "millis").andReturnValue(t);
+		}
+	}
+
+	void expect_sync(const char syn[1]) {
+		mock().expectNCalls(2, "millis").andReturnValue(0);
+		mock().expectOneCall("xmodem_write")
+			.withMemoryBufferParameter("data", (const uint8_t *)syn, 1)
+			.withParameter("timeout_ms", 1000);
+	}
+
+	void expect_packet(const char stx[1], const char seq[1],
+			const char seq_inv[1],
+			const char chksum[1], size_t data_count) {
+		mock().expectNCalls(3, "millis").andReturnValue(0);
+		mock().expectOneCall("xmodem_read")
+			.withOutputParameterReturning("buf", (const uint8_t *)stx, 1)
+			.ignoreOtherParameters()
+			.andReturnValue(1);
+
+		mock().expectOneCall("millis").andReturnValue(0);
+		mock().expectOneCall("xmodem_read")
+			.withOutputParameterReturning("buf", (const uint8_t *)seq, 1)
+			.ignoreOtherParameters()
+			.andReturnValue(1);
+		mock().expectOneCall("millis").andReturnValue(0);
+		mock().expectOneCall("xmodem_read")
+			.withOutputParameterReturning("buf", (const uint8_t *)seq_inv, 1)
+			.ignoreOtherParameters()
+			.andReturnValue(1);
+
+		for (size_t i = 0; i < data_count; i++) {
+			mock().expectOneCall("millis").andReturnValue(0);
+			mock().expectOneCall("xmodem_read")
+				.withOutputParameterReturning("buf", (const uint8_t *)"\x00", 1)
+				.ignoreOtherParameters()
+				.andReturnValue(1);
+		}
+
+		mock().expectOneCall("millis").andReturnValue(0);
+		mock().expectOneCall("xmodem_read")
+			.withOutputParameterReturning("buf", (const uint8_t *)chksum, 1)
+			.ignoreOtherParameters()
+			.andReturnValue(1);
+	}
+
+	void expect_packet_crc(const char stx[1], const char seq[1],
+			const char seq_inv[1],
+			const char crc1[1], const char crc2[1],
+			size_t data_count) {
+		expect_packet(stx, seq, seq_inv, crc1, data_count);
+		mock().expectOneCall("millis").andReturnValue(0);
+		mock().expectOneCall("xmodem_read")
+			.withOutputParameterReturning("buf", (const uint8_t *)crc2, 1)
+			.ignoreOtherParameters()
+			.andReturnValue(1);
+	}
+
+	void expect_ack(void) {
+		mock().expectOneCall("xmodem_write")
+			.withMemoryBufferParameter("data", (const uint8_t *)"\x06", 1)
+			.withParameter("timeout_ms", 1000);
+	}
+
+	void expect_eot(void) {
+		mock().expectNCalls(2, "millis").andReturnValue(0);
+		mock().expectOneCall("xmodem_read")
+			.withOutputParameterReturning("buf", (const uint8_t *)"\x04", 1)
+			.ignoreOtherParameters()
+			.andReturnValue(1);
+	}
+};
+
+TEST(XMODEM, ShouldReceiverSendNAK_WhenNotCRCSupported) {
+	mock().expectNCalls(2, "millis").andReturnValue(0);
+	expect_sync_with_no_response(0, 1000, 10, (const uint8_t[]){ 0x15 }, 1);
+
+	LONGS_EQUAL(XMODEM_ERROR_NO_RESPONSE,
+			xmodem_receive(XMODEM_DATA_BLOCK_128, 0, 0, 10000));
+}
+
+TEST(XMODEM, ShouldReceiverSendNAK_WhenNoResponseFromSenderWithC) {
+	mock().expectNCalls(2, "millis").andReturnValue(0);
+	expect_sync_with_no_response(0, 1000, 4, (const uint8_t[]){ 'C' }, 1);
+	expect_sync_with_no_response(4000, 1000, 2, (const uint8_t[]){ 0x15 }, 1);
+
+	LONGS_EQUAL(XMODEM_ERROR_NO_RESPONSE,
+			xmodem_receive(XMODEM_DATA_BLOCK_128_CRC, 0, 0, 6000));
+}
+
+TEST(XMODEM, ShouldReceiverSendNAKAfterC_When1KBlockRequestedAndNoResponse) {
+	mock().expectNCalls(2, "millis").andReturnValue(0);
+	expect_sync_with_no_response(0, 1000, 4, (const uint8_t[]){ 'C' }, 1);
+	expect_sync_with_no_response(4000, 1000, 2, (const uint8_t[]){ 0x15 }, 1);
+
+	LONGS_EQUAL(XMODEM_ERROR_NO_RESPONSE,
+			xmodem_receive(XMODEM_DATA_BLOCK_1K, 0, 0, 6000));
+}
+
+TEST(XMODEM, ShouldReceivePacketSuccessfully_WhenValidPacketReceived) {
+	expect_sync("\x15");
+
+	expect_packet("\x01", "\x01", "\xFE", "\x00", 128);
+	expect_ack();
+
+	expect_eot();
+	expect_ack();
+
+	LONGS_EQUAL(XMODEM_ERROR_NONE,
+			xmodem_receive(XMODEM_DATA_BLOCK_128, 0, 0, 10000));
+}
+
+TEST(XMODEM, ShouldReceivePacketWith16bitCRC_WhenValidPacketReceived) {
+	expect_sync("\x43");
+
+	expect_packet_crc("\x01", "\x01", "\xFE", "\x00", "\x00", 128);
+	expect_ack();
+
+	expect_eot();
+	expect_ack();
+	LONGS_EQUAL(XMODEM_ERROR_NONE,
+			xmodem_receive(XMODEM_DATA_BLOCK_128_CRC, 0, 0, 10000));
+
+	expect_sync("\x43");
+
+	expect_packet_crc("\x01", "\x01", "\xFE", "\x00", "\x00", 1024);
+	expect_ack();
+
+	expect_eot();
+	expect_ack();
+	LONGS_EQUAL(XMODEM_ERROR_NONE,
+			xmodem_receive(XMODEM_DATA_BLOCK_1K, 0, 0, 10000));
+}


### PR DESCRIPTION
This pull request introduces new functionality for CRC16 and XMODEM protocols in the `libmcu` library. The changes include adding header files, implementing the core functionalities, and creating tests to ensure the correctness of the new features.

### New Functionality:

* **CRC16 Implementation:**
  * Added `crc16_update`, `crc16_modbus`, and `crc16_xmodem` functions to perform CRC16 calculations. (`modules/common/include/libmcu/crc16.h`, `modules/common/src/crc16.c`) [[1]](diffhunk://#diff-742112e01d2f48bab8ce170705092956ba27e29c9f7e6ec50dfaeb12d93b467aR1-R26) [[2]](diffhunk://#diff-c1d90e3b8e36c91079a0bcf74ace734c283576e89c1bc9495208637652b6637fR1-R51)

* **XMODEM Protocol Implementation:**
  * Defined enums and functions for handling XMODEM protocol operations, including receiving data, setting buffers, and handling input/output operations. (`modules/common/include/libmcu/xmodem.h`, `modules/common/src/xmodem.c`) [[1]](diffhunk://#diff-d846c84f2e4354d138cac9191bdad55afdb6d5db86d9d18314036b52672b7841R1-R131) [[2]](diffhunk://#diff-ec57f5264a97e07e026f332f86159f0a33c3f342cbaa937130419bca4f8a2154R1-R299)

### Testing:

* **Test Setup:**
  * Added a new test runner and test cases for the XMODEM protocol to validate its functionality using the CppUTest framework. (`tests/runners/common/xmodem.mk`, `tests/src/common/xmodem_test.cpp`) [[1]](diffhunk://#diff-b5b9294b3475ae6b80a334c814736665188085daa1501c477ba845961ec6f07fR1-R20) [[2]](diffhunk://#diff-ab8a8b30ebcdce2937562b0f8cc20a57a88ecaa543c6a25c24b803fcf04a890cR1-R186)