### PR TITLE
interface: uart: add flush and clear buffer functions

### DIFF
--- a/interfaces/uart/include/libmcu/uart.h
+++ b/interfaces/uart/include/libmcu/uart.h
@@ -145,6 +145,28 @@ int uart_register_rx_callback(struct uart *self,
  */
 int uart_configure(struct uart *self, const struct uart_config *config);
 
+/**
+ * @brief Flush the UART interface.
+ *
+ * This function flushes the UART interface, clearing any data that may be
+ * present in the transmit buffer.
+ *
+ * @param[in] self Pointer to the UART instance.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int uart_flush(struct uart *self);
+
+/**
+ * @brief Clear the UART receive buffer.
+ *
+ * This function clears the receive buffer of the UART interface, removing any
+ * data that may be present in the receive buffer.
+ *
+ * @param[in] self Pointer to the UART instance.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int uart_clear(struct uart *self);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/ports/esp-idf/uart.c
+++ b/ports/esp-idf/uart.c
@@ -7,7 +7,9 @@
 #define UART_PARITY_EVEN	LIBMCU_UART_PARITY_EVEN
 #define UART_PARITY_ODD		LIBMCU_UART_PARITY_ODD
 #define uart_parity_t		libmcu_uart_parity_t
+#define uart_flush		libmcu_uart_flush
 #include "libmcu/uart.h"
+#undef uart_flush
 #undef uart_parity_t
 #undef UART_PARITY_ODD
 #undef UART_PARITY_EVEN
@@ -174,6 +176,32 @@ int uart_read(struct uart *self, void *buf, size_t bufsize)
 	}
 
 	return len;
+}
+
+int libmcu_uart_flush(struct uart *self)
+{
+	if (!self || !self->activated) {
+		return -EPIPE;
+	}
+
+	if (uart_wait_tx_done(self->channel, -1) != ESP_OK) {
+		return -EIO;
+	}
+
+	return 0;
+}
+
+int uart_clear(struct uart *self)
+{
+	if (!self || !self->activated) {
+		return -EPIPE;
+	}
+
+	if (uart_flush_input(self->channel) != ESP_OK) {
+		return -EIO;
+	}
+
+	return 0;
 }
 
 int uart_enable(struct uart *self, uint32_t baudrate)


### PR DESCRIPTION
This pull request introduces new functionalities to the UART interface by adding methods to flush and clear the UART buffers. These changes enhance the UART interface's ability to manage its internal buffers effectively.

New methods added:

* [`interfaces/uart/include/libmcu/uart.h`](diffhunk://#diff-3980e42cb29e9fd538c989e0ddb53be939a7206af63fc0f65828450a4ecef673R148-R169): Added `uart_flush` method to flush the UART transmit buffer.
* [`interfaces/uart/include/libmcu/uart.h`](diffhunk://#diff-3980e42cb29e9fd538c989e0ddb53be939a7206af63fc0f65828450a4ecef673R148-R169): Added `uart_clear` method to clear the UART receive buffer.

Implementation details:

* [`ports/esp-idf/uart.c`](diffhunk://#diff-c81321e06ba433f9edb3b3451f0fe5738efe076acfa80609c5c7a30c93ca7f4aR181-R206): Defined the `libmcu_uart_flush` function to implement the flushing of the UART transmit buffer.
* [`ports/esp-idf/uart.c`](diffhunk://#diff-c81321e06ba433f9edb3b3451f0fe5738efe076acfa80609c5c7a30c93ca7f4aR181-R206): Defined the `uart_clear` function to implement the clearing of the UART receive buffer.

Macro adjustments:

* [`ports/esp-idf/uart.c`](diffhunk://#diff-c81321e06ba433f9edb3b3451f0fe5738efe076acfa80609c5c7a30c93ca7f4aR10-R12): Added and then undefined the `uart_flush` macro to map to `libmcu_uart_flush`.