### PR TITLE
Add dfu module

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Any feedback would be appreciated.
 * [Button](modules/button)
 * [Command Line Interface](modules/cli)
 * [Common](modules/common)
+* [DFU](modules/dfu)
 * [FSM](modules/fsm)
 * [Logging](modules/logging)
 * [Metrics](modules/metrics)

--- a/modules/dfu/README.md
+++ b/modules/dfu/README.md
@@ -1,0 +1,27 @@
+### 이미지 헤더 생성 방법
+```sh
+python generate_dfu_header.py <file_path> <dfu_type> [vector_addr]
+```
+
+`<file_path>`는 이미지 파일이며, `<dfu_type>`는 `app`, `loader`, `updator` 중 하나입니다. `[vector_addr]`는 선택적인 인자로 벡터 테이블 주소입니다.
+
+예를 들어, `app_image.bin` 헤더를 생성할 경우 `dfu_type`을 `DFU_TYPE_APP`, `vector_addr`를 0x08000000으로 설정하려면 다음과 같이 실행합니다.
+
+```sh
+python generate_dfu_header.py app_image.bin DFU_TYPE_APP 0x08000000
+```
+
+`vector_addr` 인자를 생략하면 기본값 0이 사용됩니다.
+
+```sh
+python generate_dfu_header.py app_image.bin DFU_TYPE_APP
+```
+
+### 이미지 헤더를 바이너리 파일 앞에 붙이기
+이제 `dfu_image_header.bin` 파일과 이미지 바이너리 파일을 결합합니다. 예를 들어, 이미지 바이너리 파일이 `image.bin`이라고 가정하면, 다음 명령어를 사용하여 결합할 수 있습니다.
+
+```sh
+cat dfu_image_header.bin image.bin > combined_image.bin
+```
+
+이 명령어는 `dfu_image_header.bin` 파일과 `image.bin` 파일을 결합하여 `combined_image.bin` 파일로 저장합니다. `combined_image.bin` 파일은 구조체 데이터가 앞에 붙은 이미지 바이너리 파일입니다.

--- a/modules/dfu/generate_dfu_header.py
+++ b/modules/dfu/generate_dfu_header.py
@@ -1,0 +1,113 @@
+import struct
+import sys
+import os
+import subprocess
+import argparse
+
+MAGIC = 0xC0DE
+
+HEADER_VERSION = 1
+
+DFU_TYPE_LOADER = 2
+DFU_TYPE_UPDATOR = 3
+DFU_TYPE_APP = 4
+
+
+def get_git_tag():
+    try:
+        tag = subprocess.check_output(["git", "describe", "--tags"]).strip().decode('utf-8')
+        if tag.startswith('v'):
+            tag = tag[1:]
+        version_parts = tag.split('.')
+        if len(version_parts) != 3:
+            raise ValueError("Invalid tag format")
+        version_major = int(version_parts[0])
+        version_minor = int(version_parts[1])
+        version_patch = int(version_parts[2])
+        return version_major, version_minor, version_patch
+    except Exception as e:
+        print(f"Error getting git tag: {e}. Using default version v0.0.0")
+        return 0, 0, 0
+
+
+def get_git_commit_hash():
+    try:
+        commit_hash = subprocess.check_output(["git", "rev-parse", "--short=8", "HEAD"]).strip().decode('utf-8')
+        return bytes.fromhex(commit_hash)
+    except Exception as e:
+        print(f"Error getting git commit hash: {e}")
+        sys.exit(1)
+
+
+def generate_dfu_header(file_path, vector_addr, dfu_type, output_path, iv, signature):
+    datasize = os.path.getsize(file_path)
+    version_major, version_minor, version_patch = get_git_tag()
+    git_sha = get_git_commit_hash()
+
+    iv_nonce = bytes.fromhex(iv)
+    if len(iv_nonce) != 16:
+        print("Error: IV must be 16 bytes (32 hex characters) long.")
+        sys.exit(1)
+
+    signature_bytes = bytes.fromhex(signature)
+    if len(signature_bytes) > 64:
+        print("Error: Signature must be at most 64 bytes (128 hex characters) long.")
+        sys.exit(1)
+    elif len(signature_bytes) < 64:
+        signature_bytes = signature_bytes.ljust(64, b'\x00')
+
+    dfu_image_header = {
+        'magic': MAGIC,
+        'header_version': HEADER_VERSION,
+        'datasize': datasize,
+        'type': dfu_type,
+        'version_major': version_major,
+        'version_minor': version_minor,
+        'version_patch': version_patch,
+        'vector_addr': vector_addr,
+        'git_sha': git_sha,
+        'signature': signature_bytes,
+        'iv_nonce': iv_nonce,
+    }
+
+    dfu_image_header_format = '<HHIBBBBI8s64s16s'
+
+    dfu_image_header_binary = struct.pack(
+        dfu_image_header_format,
+        dfu_image_header['magic'],
+        dfu_image_header['header_version'],
+        dfu_image_header['datasize'],
+        dfu_image_header['type'],
+        dfu_image_header['version_major'],
+        dfu_image_header['version_minor'],
+        dfu_image_header['version_patch'],
+        dfu_image_header['vector_addr'],
+        dfu_image_header['git_sha'],
+        dfu_image_header['signature'],
+        dfu_image_header['iv_nonce']
+    )
+
+    with open(output_path, 'wb') as f:
+        f.write(dfu_image_header_binary)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate DFU header")
+    parser.add_argument('--input', required=True, help="Input file path")
+    parser.add_argument('--type', required=True, choices=['app', 'loader', 'updator'], help="DFU type")
+    parser.add_argument('--output', required=True, help="Output file path")
+    parser.add_argument('--vector', type=lambda x: int(x, 0), default=0, help="Vector address (default: 0)")
+    parser.add_argument('--iv', required=True, help="Initialization Vector (IV) as a 32-character hex string")
+    parser.add_argument('--signature', required=True, help="Signature as a hex string (up to 128 characters)")
+
+    args = parser.parse_args()
+
+    dfu_type_map = {
+        'app': DFU_TYPE_APP,
+        'loader': DFU_TYPE_LOADER,
+        'updator': DFU_TYPE_UPDATOR
+    }
+
+    dfu_type = dfu_type_map[args.type]
+
+    generate_dfu_header(args.input, args.vector, dfu_type, args.output, args.iv, args.signature)

--- a/modules/dfu/include/libmcu/dfu.h
+++ b/modules/dfu/include/libmcu/dfu.h
@@ -21,6 +21,16 @@ extern "C" {
 
 typedef enum {
 	DFU_ERROR_NONE			= 0,
+	DFU_ERROR_IO			= -1,
+	DFU_ERROR_ALLOC_FAIL		= -2,
+	DFU_ERROR_SLOT_UPDATE_FAIL	= -3,
+	DFU_ERROR_INVALID_SLOT		= -4,
+	DFU_ERROR_INVALID_IMAGE		= -5,
+	DFU_ERROR_INVALID_SIGNATURE	= -6,
+	DFU_ERROR_INVALID_PARAM		= -7,
+	DFU_ERROR_INVALID_VERSION	= -8,
+	DFU_ERROR_UNSUPPORT_VERSOIN	= -9,
+	DFU_ERROR_NOT_IMPLEMENTED	= -10,
 } dfu_error_t;
 
 typedef enum {
@@ -31,11 +41,7 @@ typedef enum {
 } dfu_type_t;
 
 typedef enum {
-	DFU_HEADER_VERSION_1		= 1,
-	DFU_HEADER_VERSION_CURRENT	= DFU_HEADER_VERSION_1,
-} dfu_header_version_t;
-
-typedef enum {
+	DFU_SLOT_CURRENT		= 0,
 	DFU_SLOT_1			= 1,
 	DFU_SLOT_2			= 2,
 	DFU_SLOT_3			= 3,
@@ -57,20 +63,83 @@ struct dfu_image_header {
 	uint8_t iv_nonce[16];
 } __attribute__((packed));
 
-dfu_error_t dfu_init(void);
-void dfu_activate(void);
-void dfu_deactivate(void);
-bool dfu_is_activated(void);
-int dfu_get_reboot_count(void);
-void dfu_increment_reboot_count(void);
-void dfu_clear_reboot_count(void);
-dfu_error_t dfu_write(dfu_slot_t slot, uint32_t offset,
+struct dfu;
+
+/**
+ * @brief Creates a new DFU (Device Firmware Update) instance.
+ *
+ * @param[in] data_block_size The size of the data block to be used for the DFU
+ *                            process.
+ *
+ * @return A pointer to the newly created DFU instance.
+ */
+struct dfu *dfu_new(size_t data_block_size);
+
+/**
+ * @brief Deletes a DFU instance.
+ *
+ * @param[in] dfu A pointer to the DFU instance to be deleted.
+ */
+void dfu_delete(struct dfu *dfu);
+
+/**
+ * @brief Prepares the DFU instance with the provided image header.
+ *
+ * @param[in,out] dfu A pointer to the DFU instance.
+ * @param[in] header A pointer to the DFU image header.
+ *
+ * @return A dfu_error_t indicating the result of the operation.
+ */
+dfu_error_t dfu_prepare(struct dfu *dfu, const struct dfu_image_header *header);
+
+/**
+ * @brief Writes data to the DFU instance at the specified offset.
+ *
+ * @param[in,out] dfu A pointer to the DFU instance.
+ * @param[in] offset The offset at which to write the data.
+ * @param[in] data A pointer to the data to be written.
+ * @param[in] datasize The size of the data to be written.
+ *
+ * @return A dfu_error_t indicating the result of the operation.
+ */
+dfu_error_t dfu_write(struct dfu *dfu, uint32_t offset,
 		const void *data, size_t datasize);
-bool dfu_is_image_valid(dfu_slot_t slot, const struct dfu_image_header *header);
+
+/**
+ * @brief Finishes the DFU process.
+ *
+ * @param[in,out] dfu A pointer to the DFU instance.
+ *
+ * @return A dfu_error_t indicating the result of the operation.
+ */
+dfu_error_t dfu_finish(struct dfu *dfu);
+
+/**
+ * @brief Commits the DFU process, making the update permanent.
+ *
+ * @param[in,out] dfu A pointer to the DFU instance.
+ *
+ * @return A dfu_error_t indicating the result of the operation.
+ */
+dfu_error_t dfu_commit(struct dfu *dfu);
+
+/**
+ * @brief Checks if the provided image header is valid.
+ *
+ * @param[in] header A pointer to the DFU image header.
+ *
+ * @return true if the header is valid, false otherwise.
+ */
+bool dfu_is_valid_header(const struct dfu_image_header *header);
+
+/**
+ * @brief Invalidates the specified DFU slot.
+ *
+ * @param[in] slot The DFU slot to be invalidated.
+ *
+ * @return A dfu_error_t indicating the result of the operation.
+ */
 dfu_error_t dfu_invalidate(dfu_slot_t slot);
-dfu_error_t dfu_commit(dfu_slot_t slot, const struct dfu_image_header *header);
-dfu_error_t dfu_get_slot_addr(dfu_slot_t slot, uintptr_t *addr);
-void dfu_jump(const struct dfu_image_header *header);
 
 #if defined(__cplusplus)
 }

--- a/modules/dfu/include/libmcu/dfu.h
+++ b/modules/dfu/include/libmcu/dfu.h
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef LIBMCU_DFU_H
+#define LIBMCU_DFU_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#if !defined(DFU_MAGIC)
+#define DFU_MAGIC			0xC0DEu
+#endif
+
+typedef enum {
+	DFU_ERROR_NONE			= 0,
+} dfu_error_t;
+
+typedef enum {
+	DFU_TYPE_BOOTLOADER		= 1,
+	DFU_TYPE_LOADER			= 2,
+	DFU_TYPE_UPDATOR		= 3,
+	DFU_TYPE_APP			= 4,
+} dfu_type_t;
+
+typedef enum {
+	DFU_HEADER_VERSION_1		= 1,
+	DFU_HEADER_VERSION_CURRENT	= DFU_HEADER_VERSION_1,
+} dfu_header_version_t;
+
+typedef enum {
+	DFU_SLOT_1			= 1,
+	DFU_SLOT_2			= 2,
+	DFU_SLOT_3			= 3,
+	DFU_SLOT_4			= 4,
+	DFU_SLOT_MAX			= DFU_SLOT_4,
+} dfu_slot_t;
+
+struct dfu_image_header {
+	uint16_t magic;
+	uint16_t header_version;
+	uint32_t datasize;
+	uint8_t type; /* image type */
+	uint8_t version_major; /* image version */
+	uint8_t version_minor;
+	uint8_t version_patch;
+	uint32_t vector_addr; /* vector table address */
+	uint8_t git_sha[8];
+	uint8_t signature[64];
+	uint8_t iv_nonce[16];
+} __attribute__((packed));
+
+dfu_error_t dfu_init(void);
+void dfu_activate(void);
+void dfu_deactivate(void);
+bool dfu_is_activated(void);
+int dfu_get_reboot_count(void);
+void dfu_increment_reboot_count(void);
+void dfu_clear_reboot_count(void);
+dfu_error_t dfu_write(dfu_slot_t slot, uint32_t offset,
+		const void *data, size_t datasize);
+bool dfu_is_image_valid(dfu_slot_t slot, const struct dfu_image_header *header);
+dfu_error_t dfu_invalidate(dfu_slot_t slot);
+dfu_error_t dfu_commit(dfu_slot_t slot, const struct dfu_image_header *header);
+dfu_error_t dfu_get_slot_addr(dfu_slot_t slot, uintptr_t *addr);
+void dfu_jump(const struct dfu_image_header *header);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* LIBMCU_DFU_H */

--- a/ports/esp-idf/board.c
+++ b/ports/esp-idf/board.c
@@ -46,20 +46,6 @@ unsigned long board_get_free_heap_bytes(void)
 	return esp_get_free_heap_size();
 }
 
-const char *board_get_serial_number_string(void)
-{
-	static char sn[13];
-
-	if (sn[0] == '\0') {
-		uint8_t mac[6] = { 0, };
-		esp_efuse_mac_get_default(mac);
-		snprintf(sn, sizeof(sn), "%02x%02x%02x%02x%02x%02x",
-				mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
-	}
-
-	return sn;
-}
-
 board_reboot_reason_t board_get_reboot_reason(void)
 {
 	switch (esp_reset_reason()) {

--- a/projects/modules.cmake
+++ b/projects/modules.cmake
@@ -3,8 +3,8 @@
 cmake_policy(SET CMP0057 NEW)
 
 if (NOT DEFINED LIBMCU_MODULES)
-	set(LIBMCU_MODULES actor ao apptimer bitmap button cli common jobqueue
-		logging metrics pubsub retry runner pm fsm)
+	set(LIBMCU_MODULES actor ao apptimer bitmap button cli common dfu
+		jobqueue logging metrics pubsub retry runner pm fsm)
 endif()
 
 if (NOT "common" IN_LIST LIBMCU_MODULES)

--- a/projects/modules.mk
+++ b/projects/modules.mk
@@ -4,8 +4,8 @@ ifneq ($(LIBMCU_ROOT),)
 libmcu-basedir := $(LIBMCU_ROOT)/
 endif
 
-LIBMCU_MODULES ?= actor ao apptimer bitmap button cli common jobqueue logging \
-		  metrics pubsub retry runner pm fsm
+LIBMCU_MODULES ?= actor ao apptimer bitmap button cli common dfu jobqueue \
+		  logging metrics pubsub retry runner pm fsm
 
 ifeq ($(filter common, $(LIBMCU_MODULES)),)
 LIBMCU_MODULES += common


### PR DESCRIPTION
This pull request introduces a new module for Device Firmware Update (DFU) and includes several related changes across different files. The most important changes are the addition of the DFU module documentation, the implementation of the DFU header generation script, and the inclusion of the DFU module in the build configuration.

### DFU Module Addition:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R25): Added a link to the new DFU module in the list of modules.
* [`modules/dfu/README.md`](diffhunk://#diff-f060c36ee65ac5f09f11a049bb693074e8b34f95ebf0b817ed2e309f7834cc77R1-R27): Added documentation on how to generate and attach a DFU header to an image file.
* [`modules/dfu/generate_dfu_header.py`](diffhunk://#diff-4ee80c17b1b9aea094bf1cba58bc3039f101c3eceb12adda4bc81a1e786cafd4R1-R113): Implemented a script to generate a DFU header, including functions to retrieve git tags and commit hashes, and to create the header based on provided parameters.
* [`modules/dfu/include/libmcu/dfu.h`](diffhunk://#diff-2d35b546b67ce98a779eb44d63d6331b3f666b9d8f283007e74e9981e4630912R1-R148): Defined the DFU header structure, error codes, DFU types, and provided function declarations for DFU operations.

### Build Configuration:

* [`projects/modules.cmake`](diffhunk://#diff-df835517b29756741e31be696c764f72041689c67adca806aa2508caecf69df0L6-R7): Added the DFU module to the list of default modules in the CMake configuration.
* [`projects/modules.mk`](diffhunk://#diff-d0f579646be3e5119f5c9fe335072f802b28b2f76be1af8f250683211445117aL7-R8): Added the DFU module to the list of default modules in the Makefile configuration.