### PR TITLE
common/xmodem: fix to cancel downloading if callback returns an error

### DIFF
--- a/modules/common/src/xmodem.c
+++ b/modules/common/src/xmodem.c
@@ -338,8 +338,11 @@ xmodem_error_t xmodem_receive(xmodem_data_block_size_t block_type,
 			if (packet.header == EOT) {
 				(*on_recv)(0, 0, 0, on_recv_ctx);
 			} else {
-				(*on_recv)(nr_packets, packet.data,
+				err = (*on_recv)(nr_packets, packet.data,
 						data_size, on_recv_ctx);
+				if (err != XMODEM_ERROR_NONE) {
+					break;
+				}
 			}
 		}
 	} while (!is_timedout(t_now, t_started, timeout_ms) &&


### PR DESCRIPTION
This pull request includes a crucial change to the `xmodem_receive` function in the `modules/common/src/xmodem.c` file. The modification introduces error handling for the `on_recv` callback function.

Error handling enhancement:

* [`modules/common/src/xmodem.c`](diffhunk://#diff-ec57f5264a97e07e026f332f86159f0a33c3f342cbaa937130419bca4f8a2154L341-R345): Modified the `xmodem_receive` function to assign the result of the `on_recv` callback to the `err` variable and break the loop if an error occurs (`err != XMODEM_ERROR_NONE`).