### PR TITLE
interface/i2c: separate bus and device api

### DIFF
--- a/ports/esp-idf/i2c.c
+++ b/ports/esp-idf/i2c.c
@@ -43,14 +43,14 @@ static int read_i2c(struct i2c_device *dev,
 		void *buf, size_t bufsize, uint32_t timeout_ms)
 {
 	pthread_mutex_lock(&dev->bus->mutex);
-	int rc = i2c_master_bus_wait_all_done(dev->bus->handle, timeout_ms);
+	int err = i2c_master_bus_wait_all_done(dev->bus->handle, timeout_ms);
 	/* FIXME: time spent on waiting for the bus is not included in the
 	 * timeout. */
-	rc |= i2c_master_receive(dev->handle, buf, bufsize, timeout_ms);
+	err |= i2c_master_receive(dev->handle, buf, bufsize, timeout_ms);
 	pthread_mutex_unlock(&dev->bus->mutex);
 
-	if (rc != ESP_OK) {
-		return -EIO;
+	if (err != ESP_OK) {
+		return -err;
 	}
 
 	return 0;
@@ -60,15 +60,15 @@ static int write_i2c(struct i2c_device *dev,
 		const void *data, size_t data_len, uint32_t timeout_ms)
 {
 	pthread_mutex_lock(&dev->bus->mutex);
-	int rc = i2c_master_bus_wait_all_done(dev->bus->handle, timeout_ms);
-	rc |= i2c_master_transmit(dev->handle, data, data_len, timeout_ms);
+	int err = i2c_master_bus_wait_all_done(dev->bus->handle, timeout_ms);
+	err |= i2c_master_transmit(dev->handle, data, data_len, timeout_ms);
 	pthread_mutex_unlock(&dev->bus->mutex);
 
-	if (rc != ESP_OK) {
-		rc = -EIO;
+	if (err != ESP_OK) {
+		return -err;
 	}
 
-	return rc;
+	return 0;
 }
 
 static int read_reg(struct i2c_device *dev,
@@ -84,13 +84,13 @@ static int read_reg(struct i2c_device *dev,
 	};
 
 	pthread_mutex_lock(&dev->bus->mutex);
-	int rc = i2c_master_bus_wait_all_done(dev->bus->handle, timeout_ms);
-	rc |= i2c_master_transmit_receive(dev->handle, &reg[4 - reg_len],
+	int err = i2c_master_bus_wait_all_done(dev->bus->handle, timeout_ms);
+	err |= i2c_master_transmit_receive(dev->handle, &reg[4 - reg_len],
 			reg_len, buf, bufsize, timeout_ms);
 	pthread_mutex_unlock(&dev->bus->mutex);
 
-	if (rc != ESP_OK) {
-		return -EIO;
+	if (err != ESP_OK) {
+		return -err;
 	}
 
 	return 0;
@@ -121,17 +121,17 @@ static int write_reg(struct i2c_device *dev,
 	}
 
 	pthread_mutex_lock(&dev->bus->mutex);
-	int rc = i2c_master_bus_wait_all_done(dev->bus->handle, timeout_ms);
-	rc |= i2c_master_transmit(dev->handle, buf, len, timeout_ms);
+	int err = i2c_master_bus_wait_all_done(dev->bus->handle, timeout_ms);
+	err |= i2c_master_transmit(dev->handle, buf, len, timeout_ms);
 	pthread_mutex_unlock(&dev->bus->mutex);
 
-	if (rc != ESP_OK) {
-		rc = -EIO;
+	if (err != ESP_OK) {
+		return -err;
 	}
 
 	free(buf);
 
-	return rc;
+	return 0;
 }
 
 static struct i2c_device *new_device(struct i2c *bus)

--- a/ports/esp-idf/i2c.c
+++ b/ports/esp-idf/i2c.c
@@ -10,24 +10,44 @@
 #include <string.h>
 #include <pthread.h>
 
-#include "driver/i2c.h" /* esp-idf */
+#include "driver/i2c_master.h" /* esp-idf */
 
-#define MAX_I2C				1
+#if !defined(I2C_MAX_BUS)
+#define I2C_MAX_BUS				1
+#endif
+#if !defined(I2C_MAX_DEVICE)
+#define I2C_MAX_DEVICE				8
+#endif
+#if !defined(I2C_CLK_SRC_DEFAULT)
+#define I2C_DEFAULT_TIMEOUT_MS			100
+#endif
+
+struct i2c_device {
+	struct i2c_device_api api;
+	struct i2c *bus;
+	uint8_t slave_addr;
+	uint32_t freq_hz;
+	i2c_master_dev_handle_t handle;
+};
 
 struct i2c {
-	struct i2c_api api;
+	struct i2c_bus_api api;
 	struct i2c_pin pin;
+	struct i2c_device devices[I2C_MAX_DEVICE];
+	i2c_master_bus_handle_t handle;
 	uint8_t channel;
 	pthread_mutex_t mutex;
 };
 
-static int read_i2c(struct i2c *self, uint8_t slave_addr,
+static int read_i2c(struct i2c_device *dev,
 		void *buf, size_t bufsize, uint32_t timeout_ms)
 {
-	pthread_mutex_lock(&self->mutex);
-	int rc = i2c_master_read_from_device(self->channel, slave_addr,
-			buf, bufsize, pdMS_TO_TICKS(timeout_ms));
-	pthread_mutex_unlock(&self->mutex);
+	pthread_mutex_lock(&dev->bus->mutex);
+        int rc = i2c_master_bus_wait_all_done(dev->bus->handle, timeout_ms);
+        /* FIXME: time spent on waiting for the bus is not included in the
+         * timeout. */
+	rc |= i2c_master_receive(dev->handle, buf, bufsize, timeout_ms);
+	pthread_mutex_unlock(&dev->bus->mutex);
 
 	if (rc != ESP_OK) {
 		return -EIO;
@@ -36,13 +56,13 @@ static int read_i2c(struct i2c *self, uint8_t slave_addr,
 	return 0;
 }
 
-static int write_i2c(struct i2c *self, uint8_t slave_addr,
+static int write_i2c(struct i2c_device *dev,
 		const void *data, size_t data_len, uint32_t timeout_ms)
 {
-	pthread_mutex_lock(&self->mutex);
-	int rc = i2c_master_write_to_device(self->channel, slave_addr,
-			data, data_len, pdMS_TO_TICKS(timeout_ms));
-	pthread_mutex_unlock(&self->mutex);
+	pthread_mutex_lock(&dev->bus->mutex);
+        int rc = i2c_master_bus_wait_all_done(dev->bus->handle, timeout_ms);
+	rc |= i2c_master_transmit(dev->handle, data, data_len, timeout_ms);
+	pthread_mutex_unlock(&dev->bus->mutex);
 
 	if (rc != ESP_OK) {
 		rc = -EIO;
@@ -51,7 +71,7 @@ static int write_i2c(struct i2c *self, uint8_t slave_addr,
 	return rc;
 }
 
-static int read_reg(struct i2c *self, uint8_t slave_addr,
+static int read_reg(struct i2c_device *dev,
 		uint32_t reg_addr, uint8_t reg_addr_bits,
 		void *buf, size_t bufsize, uint32_t timeout_ms)
 {
@@ -63,11 +83,11 @@ static int read_reg(struct i2c *self, uint8_t slave_addr,
 		(uint8_t)reg_addr
 	};
 
-	pthread_mutex_lock(&self->mutex);
-	int rc = i2c_master_write_read_device(self->channel, slave_addr,
-			&reg[4 - reg_len], reg_len, buf, bufsize,
-			pdMS_TO_TICKS(timeout_ms));
-	pthread_mutex_unlock(&self->mutex);
+	pthread_mutex_lock(&dev->bus->mutex);
+        int rc = i2c_master_bus_wait_all_done(dev->bus->handle, timeout_ms);
+	rc |= i2c_master_transmit_receive(dev->handle, &reg[4 - reg_len],
+			reg_len, buf, bufsize, timeout_ms);
+	pthread_mutex_unlock(&dev->bus->mutex);
 
 	if (rc != ESP_OK) {
 		return -EIO;
@@ -76,7 +96,7 @@ static int read_reg(struct i2c *self, uint8_t slave_addr,
 	return 0;
 }
 
-static int write_reg(struct i2c *self, uint8_t slave_addr,
+static int write_reg(struct i2c_device *dev,
 		uint32_t reg_addr, uint8_t reg_addr_bits,
 		const void *data, size_t data_len, uint32_t timeout_ms)
 {
@@ -100,10 +120,10 @@ static int write_reg(struct i2c *self, uint8_t slave_addr,
 		memcpy(&buf[reg_len], data, data_len);
 	}
 
-	pthread_mutex_lock(&self->mutex);
-	int rc = i2c_master_write_to_device(self->channel, slave_addr,
-			buf, len, pdMS_TO_TICKS(timeout_ms));
-	pthread_mutex_unlock(&self->mutex);
+	pthread_mutex_lock(&dev->bus->mutex);
+        int rc = i2c_master_bus_wait_all_done(dev->bus->handle, timeout_ms);
+        rc |= i2c_master_transmit(dev->handle, buf, len, timeout_ms);
+        pthread_mutex_unlock(&dev->bus->mutex);
 
 	if (rc != ESP_OK) {
 		rc = -EIO;
@@ -114,56 +134,126 @@ static int write_reg(struct i2c *self, uint8_t slave_addr,
 	return rc;
 }
 
-static int enable_i2c(struct i2c *self, uint32_t freq_hz)
+static struct i2c_device *new_device(struct i2c *bus)
 {
-	pthread_mutex_init(&self->mutex, NULL);
+	struct i2c_device empty = { 0, };
 
-	i2c_config_t conf = {
-		.mode = I2C_MODE_MASTER,
-		.sda_io_num = self->pin.sda,
-		.scl_io_num = self->pin.scl,
-		.sda_pullup_en = GPIO_PULLUP_ENABLE,
-		.scl_pullup_en = GPIO_PULLUP_ENABLE,
-		.master.clk_speed = freq_hz,
-	};
-
-	if (i2c_param_config(self->channel, &conf) != ESP_OK) {
-		return -EINVAL;
+	for (int i = 0; i < I2C_MAX_DEVICE; i++) {
+		struct i2c_device *dev = &bus->devices[i];
+		if (memcmp(dev, &empty, sizeof(empty)) == 0) {
+			dev->bus = bus;
+			dev->api = (struct i2c_device_api) {
+				.read = read_i2c,
+				.write = write_i2c,
+				.read_reg = read_reg,
+				.write_reg = write_reg,
+			};
+			return dev;
+		}
 	}
 
-	if (i2c_driver_install(self->channel, conf.mode, 0, 0, 0) != ESP_OK) {
-		return -EFAULT;
-	}
-
-	return 0;
+	return NULL;
 }
 
-static int disable_i2c(struct i2c *self)
+static void del_device(struct i2c_device *dev)
 {
-	pthread_mutex_destroy(&self->mutex);
+	memset(dev, 0, sizeof(*dev));
+}
 
-	if (i2c_driver_delete(self->channel) != ESP_OK) {
-		return -EFAULT;
+static struct i2c_device *create_device(struct i2c *bus,
+		uint8_t slave_addr, uint32_t freq_hz)
+{
+	struct i2c_device *dev = NULL;
+
+	pthread_mutex_lock(&bus->mutex);
+
+	if ((dev = new_device(bus)) == NULL) {
+		goto out;
 	}
 
-	return 0;
+	i2c_device_config_t conf = {
+		.scl_speed_hz = freq_hz,
+		.device_address = (uint16_t)slave_addr,
+	};
+
+	if (i2c_master_bus_add_device(bus->handle, &conf, &dev->handle)
+			!= ESP_OK) {
+		del_device(dev);
+		dev = NULL;
+	}
+
+out:
+	pthread_mutex_unlock(&bus->mutex);
+
+	return dev;
+}
+
+static void delete_device(struct i2c_device *dev)
+{
+	pthread_mutex_lock(&dev->bus->mutex);
+	i2c_master_bus_rm_device(dev->handle);
+	del_device(dev);
+	pthread_mutex_unlock(&dev->bus->mutex);
+}
+
+static int enable_i2c(struct i2c *bus)
+{
+	i2c_master_bus_config_t conf = {
+		.clk_source = I2C_CLK_SRC_DEFAULT, /* SOC_MOD_CLK_APB */
+		.i2c_port = bus->channel,
+		.scl_io_num = bus->pin.scl,
+		.sda_io_num = bus->pin.sda,
+		.glitch_ignore_cnt = 7,
+		.flags = {
+			.enable_internal_pullup = true,
+		},
+	};
+
+	int err = i2c_new_master_bus(&conf, &bus->handle);
+
+	if (err == ESP_OK) {
+		pthread_mutex_init(&bus->mutex, NULL);
+		return 0;
+	}
+
+	return -err;
+}
+
+static int disable_i2c(struct i2c *bus)
+{
+	pthread_mutex_lock(&bus->mutex);
+	int err = i2c_master_bus_wait_all_done(bus->handle,
+			I2C_DEFAULT_TIMEOUT_MS);
+	err |= i2c_del_master_bus(bus->handle);
+	pthread_mutex_unlock(&bus->mutex);
+	pthread_mutex_destroy(&bus->mutex);
+
+	return err == ESP_OK? 0 : -err;
+}
+
+static int reset_i2c(struct i2c *bus)
+{
+	pthread_mutex_lock(&bus->mutex);
+	int rc = i2c_master_bus_wait_all_done(bus->handle,
+			I2C_DEFAULT_TIMEOUT_MS);
+	rc |= i2c_master_bus_reset(bus->handle);
+	pthread_mutex_unlock(&bus->mutex);
+	return rc == ESP_OK? 0 : -rc;
 }
 
 struct i2c *i2c_create(uint8_t channel, const struct i2c_pin *pin)
 {
-	static struct i2c i2c[MAX_I2C];
+	static struct i2c i2c[I2C_MAX_BUS];
 
-	if (channel >= MAX_I2C) {
+	if (channel >= I2C_MAX_BUS) {
 		return NULL;
 	}
 
-	i2c[channel].api = (struct i2c_api) {
+	i2c[channel].api = (struct i2c_bus_api) {
 		.enable = enable_i2c,
 		.disable = disable_i2c,
-		.read = read_i2c,
-		.write = write_i2c,
-		.read_reg = read_reg,
-		.write_reg = write_reg,
+		.create_device = create_device,
+		.reset = reset_i2c,
 	};
 
 	i2c[channel].channel = channel;
@@ -175,7 +265,7 @@ struct i2c *i2c_create(uint8_t channel, const struct i2c_pin *pin)
 	return &i2c[channel];
 }
 
-void i2c_delete(struct i2c *self)
+void i2c_delete(struct i2c *bus)
 {
-	memset(self, 0, sizeof(*self));
+	memset(bus, 0, sizeof(*bus));
 }

--- a/ports/esp-idf/i2c.c
+++ b/ports/esp-idf/i2c.c
@@ -43,9 +43,9 @@ static int read_i2c(struct i2c_device *dev,
 		void *buf, size_t bufsize, uint32_t timeout_ms)
 {
 	pthread_mutex_lock(&dev->bus->mutex);
-        int rc = i2c_master_bus_wait_all_done(dev->bus->handle, timeout_ms);
-        /* FIXME: time spent on waiting for the bus is not included in the
-         * timeout. */
+	int rc = i2c_master_bus_wait_all_done(dev->bus->handle, timeout_ms);
+	/* FIXME: time spent on waiting for the bus is not included in the
+	 * timeout. */
 	rc |= i2c_master_receive(dev->handle, buf, bufsize, timeout_ms);
 	pthread_mutex_unlock(&dev->bus->mutex);
 
@@ -60,7 +60,7 @@ static int write_i2c(struct i2c_device *dev,
 		const void *data, size_t data_len, uint32_t timeout_ms)
 {
 	pthread_mutex_lock(&dev->bus->mutex);
-        int rc = i2c_master_bus_wait_all_done(dev->bus->handle, timeout_ms);
+	int rc = i2c_master_bus_wait_all_done(dev->bus->handle, timeout_ms);
 	rc |= i2c_master_transmit(dev->handle, data, data_len, timeout_ms);
 	pthread_mutex_unlock(&dev->bus->mutex);
 
@@ -84,7 +84,7 @@ static int read_reg(struct i2c_device *dev,
 	};
 
 	pthread_mutex_lock(&dev->bus->mutex);
-        int rc = i2c_master_bus_wait_all_done(dev->bus->handle, timeout_ms);
+	int rc = i2c_master_bus_wait_all_done(dev->bus->handle, timeout_ms);
 	rc |= i2c_master_transmit_receive(dev->handle, &reg[4 - reg_len],
 			reg_len, buf, bufsize, timeout_ms);
 	pthread_mutex_unlock(&dev->bus->mutex);
@@ -121,9 +121,9 @@ static int write_reg(struct i2c_device *dev,
 	}
 
 	pthread_mutex_lock(&dev->bus->mutex);
-        int rc = i2c_master_bus_wait_all_done(dev->bus->handle, timeout_ms);
-        rc |= i2c_master_transmit(dev->handle, buf, len, timeout_ms);
-        pthread_mutex_unlock(&dev->bus->mutex);
+	int rc = i2c_master_bus_wait_all_done(dev->bus->handle, timeout_ms);
+	rc |= i2c_master_transmit(dev->handle, buf, len, timeout_ms);
+	pthread_mutex_unlock(&dev->bus->mutex);
 
 	if (rc != ESP_OK) {
 		rc = -EIO;


### PR DESCRIPTION
This pull request includes significant changes to the I2C interface and implementation, introducing a new device abstraction and modifying the existing bus operations. The changes primarily focus on separating the bus and device functionalities and updating the API accordingly.

### Changes to I2C Interface:
* Introduced `struct i2c_device` and `struct i2c_device_api` to separate device-specific operations from bus operations in `interfaces/i2c/include/libmcu/i2c.h`.
* Updated inline functions to use `struct i2c_device` for device-specific operations and added new functions for creating and deleting devices.

### Changes to I2C Implementation:
* Updated the I2C implementation to use the new device abstraction, including changes to `read`, `write`, `read_reg`, and `write_reg` functions to operate on `struct i2c_device` instead of `struct i2c`. [[1]](diffhunk://#diff-b89106f88021ccae3e97ce8b36e0f909cbfd03283073ca3abc725863fabe7e81L13-R50) [[2]](diffhunk://#diff-b89106f88021ccae3e97ce8b36e0f909cbfd03283073ca3abc725863fabe7e81L39-R65) [[3]](diffhunk://#diff-b89106f88021ccae3e97ce8b36e0f909cbfd03283073ca3abc725863fabe7e81L54-R74) [[4]](diffhunk://#diff-b89106f88021ccae3e97ce8b36e0f909cbfd03283073ca3abc725863fabe7e81L66-R90) [[5]](diffhunk://#diff-b89106f88021ccae3e97ce8b36e0f909cbfd03283073ca3abc725863fabe7e81L79-R99) [[6]](diffhunk://#diff-b89106f88021ccae3e97ce8b36e0f909cbfd03283073ca3abc725863fabe7e81L103-R126)
* Added functions for creating and deleting devices, and updated the bus enable and disable functions to handle the new device abstraction. [[1]](diffhunk://#diff-b89106f88021ccae3e97ce8b36e0f909cbfd03283073ca3abc725863fabe7e81L117-R256) [[2]](diffhunk://#diff-b89106f88021ccae3e97ce8b36e0f909cbfd03283073ca3abc725863fabe7e81L178-R270)

These changes improve the modularity and scalability of the I2C interface by clearly separating bus and device operations, making it easier to manage multiple devices on a single bus.