### PR TITLE
buzzer: remove misused macro

### DIFF
--- a/modules/buzzer/src/buzzer.c
+++ b/modules/buzzer/src/buzzer.c
@@ -10,9 +10,6 @@
 #include <stdint.h>
 #include <semaphore.h>
 
-#define timer_start libmcu_timer_start
-#define timer_create libmcu_timer_create
-#define timer_delete libmcu_timer_delete
 #include "libmcu/timer.h"
 
 struct playing {

--- a/ports/esp-idf/timer.c
+++ b/ports/esp-idf/timer.c
@@ -1,6 +1,4 @@
 #include "esp_timer.h"
-#define timer_create libmcu_timer_create
-#define timer_delete libmcu_timer_delete
 #include "libmcu/timer.h"
 
 #if !defined(TIMER_MAX)


### PR DESCRIPTION
This pull request includes changes to the timer-related code in the `buzzer` and `esp-idf` modules. The changes primarily focus on the removal of redundant macro definitions for timer functions.

Codebase simplification:

* [`modules/buzzer/src/buzzer.c`](diffhunk://#diff-0d9d2edb2ec30d199b71f27d61489db04f1d2c26ff5d9f2983d751e901b20c54L13-L15): Removed unnecessary macro definitions for `timer_start`, `timer_create`, and `timer_delete`.
* [`ports/esp-idf/timer.c`](diffhunk://#diff-4d86c507d45d70883d1b35f16cda8dbb8a61aacaa6a9d16bcf60d144a339bd5eL2-L3): Removed unnecessary macro definitions for `timer_create` and `timer_delete`.