### PR TITLE
Add board_get_time_since_boot_us()

### DIFF
--- a/modules/common/include/libmcu/board.h
+++ b/modules/common/include/libmcu/board.h
@@ -43,6 +43,7 @@ board_reboot_reason_t board_get_reboot_reason(void);
 const char *board_get_reboot_reason_string(board_reboot_reason_t reason);
 
 unsigned long board_get_time_since_boot_ms(void);
+uint64_t board_get_time_since_boot_us(void);
 
 int board_register_idle_hook(int opt, board_idle_hook_t func);
 uint32_t board_random(void);

--- a/ports/esp-idf/board.c
+++ b/ports/esp-idf/board.c
@@ -29,6 +29,12 @@ unsigned long board_get_time_since_boot_ms(void)
 }
 
 LIBMCU_NO_INSTRUMENT
+uint64_t board_get_time_since_boot_us(void)
+{
+	return (uint64_t)esp_timer_get_time();
+}
+
+LIBMCU_NO_INSTRUMENT
 unsigned long board_get_current_stack_watermark(void)
 {
 	return (unsigned long)uxTaskGetStackHighWaterMark(NULL);


### PR DESCRIPTION
This pull request introduces a new function to retrieve the time since boot in microseconds in the `libmcu` library. The most important changes include the addition of the `board_get_time_since_boot_us` function in both the header and implementation files.

Changes to time retrieval functions:

* [`modules/common/include/libmcu/board.h`](diffhunk://#diff-1e5b02b71826ba33a41a6e46b0c8164e2fb75fc8efa39cc3fe6f6640db54c38eR46): Added a declaration for the `board_get_time_since_boot_us` function to provide an interface for retrieving the time since boot in microseconds.
* [`ports/esp-idf/board.c`](diffhunk://#diff-caaefac8e985b5380266159453573db47e4042c4e872c7b1494f30a3bb6d681fR31-R36): Implemented the `board_get_time_since_boot_us` function using `esp_timer_get_time` to return the time since boot in microseconds.