### PR TITLE
pwm: esp-idf: handle errors in PWM functions

### DIFF
--- a/ports/esp-idf/pwm.c
+++ b/ports/esp-idf/pwm.c
@@ -94,8 +94,8 @@ static void initialize_ledc(struct pwm *self, int ch, int pin)
 
 static int update_frequency(struct pwm_channel *ch, uint32_t hz)
 {
-	ledc_set_freq(ch->pwm->speed_mode, ch->pwm->timer, hz);
-	return 0;
+	int err = ledc_set_freq(ch->pwm->speed_mode, ch->pwm->timer, hz);
+	return err == ESP_OK ? 0 : -err;
 }
 
 static int update_duty(struct pwm_channel *ch, uint32_t millipercent)
@@ -120,10 +120,10 @@ static int update_duty(struct pwm_channel *ch, uint32_t millipercent)
 
 	uint32_t duty = resolution * millipercent / 100000;
 
-	ledc_set_duty(ch->pwm->speed_mode, ch->id, duty);
-	ledc_update_duty(ch->pwm->speed_mode, ch->id);
+	int err = ledc_set_duty(ch->pwm->speed_mode, ch->id, duty);
+	err |= ledc_update_duty(ch->pwm->speed_mode, ch->id);
 
-	return 0;
+	return err == ESP_OK ? 0 : -err;
 }
 
 int pwm_update_duty(struct pwm_channel *ch, uint32_t millipercent)
@@ -139,15 +139,15 @@ int pwm_update_frequency(struct pwm_channel *ch, uint32_t hz)
 int pwm_start(struct pwm_channel *ch,
 		uint32_t freq_hz, uint32_t duty_millipercent)
 {
-	update_frequency(ch, freq_hz);
-	update_duty(ch, duty_millipercent);
-	return 0;
+	int err = update_frequency(ch, freq_hz);
+	err |= update_duty(ch, duty_millipercent);
+	return err;
 }
 
 int pwm_stop(struct pwm_channel *ch)
 {
-	ledc_stop(ch->pwm->speed_mode, ch->id, 0);
-	return 0;
+	int err = ledc_stop(ch->pwm->speed_mode, ch->id, 0);
+	return err == ESP_OK ? 0 : -err;
 }
 
 int pwm_enable(struct pwm_channel *ch)


### PR DESCRIPTION
This pull request includes several changes to the `ports/esp-idf/pwm.c` file, primarily focused on improving error handling for PWM operations. The key changes involve modifying functions to return error codes instead of always returning 0.

Error handling improvements:

* `static int update_frequency(struct pwm_channel *ch, uint32_t hz)`: Modified to return an error code if `ledc_set_freq` fails.
* `static int update_duty(struct pwm_channel *ch, uint32_t millipercent)`: Modified to return an error code if either `ledc_set_duty` or `ledc_update_duty` fails.
* `int pwm_start(struct pwm_channel *ch, uint32_t freq_hz, uint32_t duty_millipercent)`: Modified to return an error code if either `update_frequency` or `update_duty` fails.
* [`int pwm_stop(struct pwm_channel *ch)`](diffhunk://#diff-4b8e57a85f057ec4c6806637bed031c938fbeb22c8e30a22421cf4d5aa966609L142-R150): Modified to return an error code if `ledc_stop` fails.