### PR TITLE
test: add mock and stub implementations

### DIFF
--- a/tests/mocks/assert.cpp
+++ b/tests/mocks/assert.cpp
@@ -1,0 +1,8 @@
+#include "CppUTestExt/MockSupport.h"
+#include "libmcu/assert.h"
+
+void libmcu_assertion_failed(const uintptr_t *pc, const uintptr_t *lr) {
+	mock().actualCall("libmcu_assertion_failed")
+		.withParameter("pc", pc)
+		.withParameter("lr", lr);
+}

--- a/tests/mocks/pwm.cpp
+++ b/tests/mocks/pwm.cpp
@@ -1,0 +1,76 @@
+#include "CppUTestExt/MockSupport.h"
+#include "libmcu/pwm.h"
+
+struct pwm_channel {
+	int dummy;
+};
+
+struct pwm {
+	struct pwm_channel dummy;
+};
+
+struct pwm *pwm_create(uint8_t timer) {
+	return (struct pwm *)mock().actualCall("pwm_create")
+		.withParameter("timer", timer)
+		.returnPointerValue();
+}
+
+int pwm_delete(struct pwm *self) {
+	return mock().actualCall("pwm_delete")
+		.withParameter("self", self)
+		.returnIntValue();
+}
+
+struct pwm_channel *pwm_create_channel(struct pwm *self, int ch, int pin) {
+	return (struct pwm_channel *)mock().actualCall("pwm_create_channel")
+		.withParameter("self", self)
+		.withParameter("ch", ch)
+		.withParameter("pin", pin)
+		.returnPointerValue();
+}
+
+int pwm_delete_channel(struct pwm_channel *ch) {
+	return mock().actualCall("pwm_delete_channel")
+		.withParameter("ch", ch)
+		.returnIntValue();
+}
+
+int pwm_enable(struct pwm_channel *ch) {
+	return mock().actualCall("pwm_enable")
+		.withParameter("ch", ch)
+		.returnIntValue();
+}
+
+int pwm_disable(struct pwm_channel *ch) {
+	return mock().actualCall("pwm_disable")
+		.withParameter("ch", ch)
+		.returnIntValue();
+}
+
+int pwm_start(struct pwm_channel *ch, uint32_t freq_hz, uint32_t duty_millipercent) {
+	return mock().actualCall("pwm_start")
+		.withParameter("ch", ch)
+		.withParameter("freq_hz", freq_hz)
+		.withParameter("duty_millipercent", duty_millipercent)
+		.returnIntValue();
+}
+
+int pwm_stop(struct pwm_channel *ch) {
+	return mock().actualCall("pwm_stop")
+		.withParameter("ch", ch)
+		.returnIntValue();
+}
+
+int pwm_update_frequency(struct pwm_channel *ch, uint32_t hz) {
+	return mock().actualCall("pwm_update_frequency")
+		.withParameter("ch", ch)
+		.withParameter("hz", hz)
+		.returnIntValue();
+}
+
+int pwm_update_duty(struct pwm_channel *ch, uint32_t millipercent) {
+	return mock().actualCall("pwm_update_duty")
+		.withParameter("ch", ch)
+		.withParameter("millipercent", millipercent)
+		.returnIntValue();
+}

--- a/tests/mocks/timer.cpp
+++ b/tests/mocks/timer.cpp
@@ -1,0 +1,55 @@
+#include "CppUTestExt/MockSupport.h"
+#include "libmcu/timer.h"
+
+struct timer {
+	struct timer_api api;
+};
+
+static int enable(struct timer *self) {
+	return mock().actualCall("timer_enable")
+		.withParameter("self", self)
+		.returnIntValue();
+}
+
+static int disable(struct timer *self) {
+	return mock().actualCall("timer_disable")
+		.withParameter("self", self)
+		.returnIntValue();
+}
+
+static int start(struct timer *self, uint32_t timeout_ms) {
+	return mock().actualCall("timer_start")
+		.withParameter("self", self)
+		.withParameter("timeout_ms", timeout_ms)
+		.returnIntValue();
+}
+
+static int restart(struct timer *self, uint32_t timeout_ms) {
+	return mock().actualCall("timer_restart")
+		.withParameter("self", self)
+		.withParameter("timeout_ms", timeout_ms)
+		.returnIntValue();
+}
+
+static int stop(struct timer *self) {
+	return mock().actualCall("timer_stop")
+		.withParameter("self", self)
+		.returnIntValue();
+}
+
+struct timer *timer_create(bool periodic, timer_callback_t callback, void *arg)
+{
+	struct timer *self = new struct timer;
+	self->api.enable = enable;
+	self->api.disable = disable;
+	self->api.start = start;
+	self->api.restart = restart;
+	self->api.stop = stop;
+	return self;
+}
+
+int timer_delete(struct timer *self)
+{
+	delete self;
+	return 0;
+}

--- a/tests/stubs/board.cpp
+++ b/tests/stubs/board.cpp
@@ -2,13 +2,13 @@
 #include "libmcu/board.h"
 
 unsigned long board_get_time_since_boot_ms(void) {
-	return mock().actualCall(__func__).returnUnsignedIntValue();
+	return 0;
 }
 
 uint64_t board_get_time_since_boot_us(void) {
-	return mock().actualCall(__func__).returnUnsignedIntValue();
+	return 0;
 }
 
 void board_reboot(void) {
-	mock().actualCall(__func__);
+	return;
 }

--- a/tests/stubs/overrides/libmcu/metrics.h
+++ b/tests/stubs/overrides/libmcu/metrics.h
@@ -22,6 +22,7 @@ typedef uint16_t metric_key_t;
 #define metrics_collect(a, b)
 #define metrics_count()
 #define metrics_init(x)
+#define metrics_is_set(x)
 #if !defined(METRICS_NO_KEY_STRING)
 #define metrics_stringify_key(k)
 #endif


### PR DESCRIPTION
This pull request includes several changes to add mock implementations for various components and stub implementations for board-related functions. The most important changes are grouped by theme and summarized below.

Mock Implementations:

* Added mock implementation for `libmcu_assertion_failed` in `tests/mocks/assert.cpp`.
* Added mock implementation for `board_get_time_since_boot_us` in `tests/mocks/board.cpp`.
* Added comprehensive mock implementation for PWM-related functions in `tests/mocks/pwm.cpp`.
* Added mock implementation for timer-related functions in `tests/mocks/timer.cpp`.

Stub Implementations:

* Added stub implementations for board-related functions in `tests/stubs/board.cpp`.

Minor Macro Addition:

* Added `metrics_is_set` macro definition in `tests/stubs/overrides/libmcu/metrics.h`.