### PR TITLE
interface/gpio: add interrupt enable/disable functions

### DIFF
--- a/interfaces/gpio/include/libmcu/gpio.h
+++ b/interfaces/gpio/include/libmcu/gpio.h
@@ -21,6 +21,8 @@ typedef void (*gpio_callback_t)(struct gpio *gpio, void *ctx);
 struct gpio_api {
 	int (*enable)(struct gpio *self);
 	int (*disable)(struct gpio *self);
+	int (*enable_interrupt)(struct gpio *self);
+	int (*disable_interrupt)(struct gpio *self);
 	int (*set)(struct gpio *self, int value);
 	int (*get)(struct gpio *self);
 	int (*register_callback)(struct gpio *self,
@@ -33,6 +35,14 @@ static inline int gpio_enable(struct gpio *self) {
 
 static inline int gpio_disable(struct gpio *self) {
 	return ((struct gpio_api *)self)->disable(self);
+}
+
+static inline int gpio_enable_interrupt(struct gpio *self) {
+	return ((struct gpio_api *)self)->enable_interrupt(self);
+}
+
+static inline int gpio_disable_interrupt(struct gpio *self) {
+	return ((struct gpio_api *)self)->disable_interrupt(self);
 }
 
 static inline int gpio_set(struct gpio *self, int value) {


### PR DESCRIPTION
This pull request includes changes to the GPIO interface to add support for enabling and disabling interrupts. The most important changes are summarized below:

Enhancements to GPIO interface:

* [`interfaces/gpio/include/libmcu/gpio.h`](diffhunk://#diff-1169c94f6b745dbdd8a13bb8a5f7430c4c8804d24619b97ece4f81f1c6dd7ad3R24-R25): Added `enable_interrupt` and `disable_interrupt` function pointers to the `gpio_api` structure.
* [`interfaces/gpio/include/libmcu/gpio.h`](diffhunk://#diff-1169c94f6b745dbdd8a13bb8a5f7430c4c8804d24619b97ece4f81f1c6dd7ad3R40-R47): Added inline functions `gpio_enable_interrupt` and `gpio_disable_interrupt` to call the corresponding function pointers in the `gpio_api` structure.