### PR TITLE
button: fix to return busy until click window closed

### DIFF
--- a/modules/button/include/libmcu/button.h
+++ b/modules/button/include/libmcu/button.h
@@ -153,12 +153,13 @@ button_error_t button_step_delta(struct button *btn, const uint32_t delta_ms);
 /**
  * @brief Checks if the button is currently busy.
  *
- * @param btn Pointer to the button instance.
+ * This function checks the status of the specified button to determine if
+ * it is currently busy. A button is considered busy if it is in the middle
+ * of a state transition or an ongoing operation.
  *
- * @note A button is considered busy when it is in the process of detecting like
- *       in the period of debouncing.
+ * @param[in] btn Pointer to the button structure.
  *
- * @return True if the button is busy, false otherwise.
+ * @return bool True if the button is busy, false otherwise.
  */
 bool button_busy(const struct button *btn);
 


### PR DESCRIPTION
This pull request includes several changes to the button module, focusing on improving the button state management and handling of button press timings. The key changes involve modifications to the `process_button`, `process_pressed`, and `process_released` functions, as well as updates to the `button_busy` function.

Improvements to button state management:

* [`modules/button/src/button.c`](diffhunk://#diff-d6c2306ea79d96d11dec0c8ef63b96cf919735ac06a6f9d999a778391c55102aR266): Updated the `process_button` function to use a corrected timestamp (`time_corrected`) for button state synchronization and processing. This change ensures more accurate handling of button press timings. [[1]](diffhunk://#diff-d6c2306ea79d96d11dec0c8ef63b96cf919735ac06a6f9d999a778391c55102aR266) [[2]](diffhunk://#diff-d6c2306ea79d96d11dec0c8ef63b96cf919735ac06a6f9d999a778391c55102aL275-R302)
* [`modules/button/src/button.c`](diffhunk://#diff-d6c2306ea79d96d11dec0c8ef63b96cf919735ac06a6f9d999a778391c55102aR217-R218): Modified the `process_pressed` function to reset `time_repeat` and `repeats` when a button is pressed. This change ensures that repeat counts are correctly initialized.
* [`modules/button/src/button.c`](diffhunk://#diff-d6c2306ea79d96d11dec0c8ef63b96cf919735ac06a6f9d999a778391c55102aL226-L227): Removed the reset of `time_repeat` and `repeats` from the `process_released` function to avoid unnecessary reinitialization when a button is released.

Enhancements to button status checking:

* [`modules/button/src/button.c`](diffhunk://#diff-d6c2306ea79d96d11dec0c8ef63b96cf919735ac06a6f9d999a778391c55102aL392-R384): Enhanced the `button_busy` function to consider the click window status in addition to the button being up. This change provides a more accurate determination of whether the button is busy.

Documentation updates:

* [`modules/button/include/libmcu/button.h`](diffhunk://#diff-791d7b04d38efdcbdeb8bf3f4b283705a4e5a020dbe885ae046226fb385148a5L156-R162): Updated the documentation for the `button_busy` function to provide a clearer description of when a button is considered busy.Enter concise *title* on top, update *reviewers*, *labels*, *milestone* on the side, and write up *description* below.
