### PR TITLE
interface/wdt: add watchdog timer interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Any feedback would be appreciated.
 * [SPI](interfaces/spi)
 * [Timer](interfaces/timer)
 * [UART](interfaces/uart)
+* [WDT](interfaces/wdt)
 * [WiFi](interfaces/wifi)
 
 ## Integration Guide

--- a/interfaces/wdt/include/libmcu/wdt.h
+++ b/interfaces/wdt/include/libmcu/wdt.h
@@ -32,6 +32,15 @@ typedef void (*wdt_timeout_cb_t)(struct wdt *wdt, void *ctx);
 int wdt_init(wdt_timeout_cb_t cb, void *cb_ctx);
 
 /**
+ * @brief Deinitialize the watchdog timer.
+ *
+ * This function deinitializes the watchdog timer, releasing any resources
+ * that were allocated during initialization. It should be called when the
+ * watchdog timer is no longer needed.
+ */
+void wdt_deinit(void);
+
+/**
  * @brief Create a new watchdog timer instance.
  *
  * @return Pointer to the newly created watchdog timer instance,

--- a/interfaces/wdt/include/libmcu/wdt.h
+++ b/interfaces/wdt/include/libmcu/wdt.h
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef LIBMCU_WDT_H
+#define LIBMCU_WDT_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+struct wdt;
+
+/**
+ * @brief Callback function type for watchdog timeout.
+ *
+ * @param[in] wdt Pointer to the watchdog instance.
+ * @param[in] ctx User-defined context for the callback.
+ */
+typedef void (*wdt_timeout_cb_t)(struct wdt *wdt, void *ctx);
+
+/**
+ * @brief Initialize the watchdog timer.
+ *
+ * @param[in] cb Callback function to be called on watchdog timeout.
+ * @param[in] cb_ctx User-defined context to be passed to the callback function.
+ *
+ * @return 0 on success, negative error code on failure.
+ */
+int wdt_init(wdt_timeout_cb_t cb, void *cb_ctx);
+
+/**
+ * @brief Create a new watchdog timer instance.
+ *
+ * @return Pointer to the newly created watchdog timer instance,
+ *                 or NULL on failure.
+ */
+struct wdt *wdt_new(void);
+
+/**
+ * @brief Delete a watchdog timer instance.
+ *
+ * @param[in] self Pointer to the watchdog timer instance to be deleted.
+ */
+void wdt_delete(struct wdt *self);
+
+/**
+ * @brief Feed (reset) the watchdog timer.
+ *
+ * @param[in] self Pointer to the watchdog timer instance.
+ *
+ * @return 0 on success, negative error code on failure.
+ */
+int wdt_feed(struct wdt *self);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* LIBMCU_WDT_H */

--- a/ports/esp-idf/wdt.c
+++ b/ports/esp-idf/wdt.c
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "libmcu/wdt.h"
+#include <stdlib.h>
+#include "esp_task_wdt.h"
+#include "libmcu/board.h"
+
+struct wdt {
+	void *task_handle;
+};
+
+struct wdt_manager {
+	wdt_timeout_cb_t cb;
+	void *cb_ctx;
+};
+
+static struct wdt_manager mgr;
+
+int wdt_feed(struct wdt *self)
+{
+	(void)self;
+	int err = esp_task_wdt_reset();
+	return err == ESP_OK ? 0 : -err;
+}
+
+struct wdt *wdt_new(void)
+{
+	struct wdt *self = (struct wdt *)malloc(sizeof(*self));
+
+	if (self) {
+		self->task_handle = board_get_current_thread();
+	}
+	
+	int err = esp_task_wdt_add(NULL);
+
+	return err == ESP_OK? self : NULL;
+}
+
+void wdt_delete(struct wdt *self)
+{
+	esp_task_wdt_delete(NULL);
+	free(self);
+}
+
+int wdt_init(wdt_timeout_cb_t cb, void *cb_ctx)
+{
+	int err = 0;
+
+	mgr.cb = cb;
+	mgr.cb_ctx = cb_ctx;
+
+#if !CONFIG_ESP_TASK_WDT_INIT
+	esp_task_wdt_config_t twdt_config = {
+		.timeout_ms = CONFIG_TASK_WDT_TIMEOUT_S,
+		.idle_core_mask = (1 << CONFIG_FREERTOS_NUMBER_OF_CORES) - 1,
+		.trigger_panic = false,
+	};
+	err = esp_task_wdt_init(&twdt_config);
+	err = err == ESP_OK? 0 : -err;
+#endif
+
+	return err;
+}
+
+void wdt_deinit(void)
+{
+#if !CONFIG_ESP_TASK_WDT_INIT
+	ESP_ERROR_CHECK(esp_task_wdt_deinit());
+#endif
+}

--- a/projects/interfaces.cmake
+++ b/projects/interfaces.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 if (NOT DEFINED LIBMCU_INTERFACES)
-	set(LIBMCU_INTERFACES adc ble flash gpio i2c kvstore l4 pwm spi timer uart wifi)
+	set(LIBMCU_INTERFACES adc ble flash gpio i2c kvstore l4 pwm spi timer uart wdt wifi)
 endif()
 
 foreach(iface ${LIBMCU_INTERFACES})

--- a/projects/interfaces.mk
+++ b/projects/interfaces.mk
@@ -4,7 +4,7 @@ ifneq ($(LIBMCU_ROOT),)
 libmcu-basedir := $(LIBMCU_ROOT)/
 endif
 
-LIBMCU_INTERFACES ?= adc ble flash gpio i2c kvstore l4 pwm spi timer uart wifi
+LIBMCU_INTERFACES ?= adc ble flash gpio i2c kvstore l4 pwm spi timer uart wdt wifi
 
 LIBMCU_INTERFACES_INCS := $(foreach d, $(LIBMCU_INTERFACES), \
 	$(addprefix $(libmcu-basedir)interfaces/, $(d))/include)


### PR DESCRIPTION
This pull request introduces the watchdog timer (WDT) interface to the project, including its documentation, header files, and implementation for the ESP-IDF platform. The most important changes include adding the WDT interface to various configuration files, creating the WDT header file, and implementing the WDT functions.

### Watchdog Timer (WDT) Interface Addition:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R48): Added WDT to the list of interfaces.
* [`projects/interfaces.cmake`](diffhunk://#diff-7d719d0df21940c3079a044caa520bba4e7039370db576703b5c913ab3be48e4L4-R4): Included WDT in the `LIBMCU_INTERFACES` list.
* [`projects/interfaces.mk`](diffhunk://#diff-2527f63252f6d07ed1ae138927202e3be2032d9e576778c5279a3e99daf33a75L7-R7): Added WDT to the `LIBMCU_INTERFACES` variable.

### WDT Header File:

* [`interfaces/wdt/include/libmcu/wdt.h`](diffhunk://#diff-032b2570ef43cb2b2670d62de7dd2fb6afae8995372bf444b6e1b2f3ba6abab0R1-R71): Created the WDT header file with function declarations and documentation.

### WDT Implementation for ESP-IDF:

* [`ports/esp-idf/wdt.c`](diffhunk://#diff-73dff416cfe64f39bc8a2a9aca2f934e745ff0577114f6ba95082d0640576844R1-R74): Implemented the WDT functions including initialization, feeding, and deletion, along with necessary includes and structure definitions.