### PR TITLE
test: add test stubs for WDT interface

### DIFF
--- a/tests/stubs/wdt.cpp
+++ b/tests/stubs/wdt.cpp
@@ -1,0 +1,32 @@
+#include "libmcu/wdt.h"
+
+struct wdt {
+	int dummy;
+};
+
+struct wdt *wdt_new(const uint32_t period_ms, wdt_timeout_cb_t cb, void *cb_ctx) {
+	static struct wdt wdt;
+	return &wdt;
+}
+
+void wdt_delete(struct wdt *self) {
+	(void)self;
+}
+
+int wdt_register_timeout_cb(wdt_timeout_cb_t cb, void *cb_ctx) {
+	(void)cb;
+	(void)cb_ctx;
+	return 0;
+}
+
+int wdt_feed(struct wdt *self) {
+	(void)self;
+	return 0;
+}
+
+int wdt_init(void) {
+	return 0;
+}
+
+void wdt_deinit(void) {
+}


### PR DESCRIPTION
This pull request introduces a new stub for the watchdog timer (WDT) in the `tests/stubs/wdt.cpp` file. The changes include the addition of several functions to manage the WDT, such as creating, deleting, and feeding the WDT, as well as registering a timeout callback.

Key changes:

* [`tests/stubs/wdt.cpp`](diffhunk://#diff-093b7d852335938e785c0a745eb4edac2ecc9454dc523b88c5bedadc73cb1738R1-R32): Added a new stub implementation for the watchdog timer (WDT), including functions for creating (`wdt_new`), deleting (`wdt_delete`), feeding (`wdt_feed`), and initializing (`wdt_init` and `wdt_deinit`) the WDT. Additionally, a function for registering a timeout callback (`wdt_register_timeout_cb`) was added.