### PR TITLE
Add cleanup module with priority-based execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Any feedback would be appreciated.
 * [Application Timer](modules/apptimer)
 * [Button](modules/button)
 * [Buzzer](modules/buzzer)
+* [Cleanup](modules/cleanup)
 * [Command Line Interface](modules/cli)
 * [Common](modules/common)
 * [DFU](modules/dfu)

--- a/modules/cleanup/include/libmcu/cleanup.h
+++ b/modules/cleanup/include/libmcu/cleanup.h
@@ -55,6 +55,11 @@ cleanup_error_t cleanup_register(int priority,
 
 /**
  * @brief Execute all registered cleanup functions in order of their priority.
+ *
+ * This function will call all registered cleanup functions in order of their
+ * priority, from highest to lowest. When the same priority is given, the
+ * cleanup functions are called first come, first serve style (FIFO) in the
+ * order they were registered.
  */
 void cleanup_execute(void);
 

--- a/modules/cleanup/include/libmcu/cleanup.h
+++ b/modules/cleanup/include/libmcu/cleanup.h
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef LIBMCU_CLEANUP_H
+#define LIBMCU_CLEANUP_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * @brief Enumeration of possible cleanup errors.
+ */
+typedef enum {
+	CLEANUP_ERROR_NONE,           /**< No error occurred. */
+	CLEANUP_ERROR_ALLOC_FAILED,   /**< Allocation failed. */
+} cleanup_error_t;
+
+/**
+ * @brief Type definition for cleanup function pointer.
+ *
+ * @param[in] ctx Context pointer to be passed to the cleanup function.
+ */
+typedef void (*cleanup_func_t)(void *ctx);
+
+/**
+ * @brief Initialize the cleanup module.
+ *
+ * @return CLEANUP_ERROR_NONE on success, or an appropriate error code on
+ *         failure.
+ */
+cleanup_error_t cleanup_init(void);
+
+/**
+ * @brief Deinitialize the cleanup module.
+ */
+void cleanup_deinit(void);
+
+/**
+ * @brief Register a cleanup function to be called during cleanup.
+ *
+ * @param[in] priority The priority of the cleanup function. Higher priority
+ *                     functions are called first.
+ * @param[in] func The cleanup function to register.
+ * @param[in] func_ctx The context to be passed to the cleanup function.
+ *
+ * @return CLEANUP_ERROR_NONE on success, or an appropriate error code on
+ *         failure.
+ */
+cleanup_error_t cleanup_register(int priority,
+		cleanup_func_t func, void *func_ctx);
+
+/**
+ * @brief Execute all registered cleanup functions in order of their priority.
+ */
+void cleanup_execute(void);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* LIBMCU_CLEANUP_H */

--- a/modules/cleanup/src/cleanup.c
+++ b/modules/cleanup/src/cleanup.c
@@ -51,8 +51,8 @@ cleanup_error_t cleanup_register(int priority,
 
 	struct list **p = &m.list.next;
 	while (*p != &m.list) {
-		struct cleanup *tmp = list_entry(*p, struct cleanup, link);
-		if (priority > tmp->priority) {
+		const struct cleanup *t = list_entry(*p, struct cleanup, link);
+		if (priority > t->priority) {
 			break;
 		}
 		p = &(*p)->next;

--- a/modules/cleanup/src/cleanup.c
+++ b/modules/cleanup/src/cleanup.c
@@ -1,0 +1,82 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "libmcu/cleanup.h"
+#include <stdlib.h>
+#include "libmcu/list.h"
+
+struct cleanup {
+	struct list link;
+
+	cleanup_func_t func;
+	void *func_ctx;
+
+	int priority;
+};
+
+struct cleanup_manager {
+	struct list list;
+};
+
+static struct cleanup_manager m;
+
+void cleanup_execute(void)
+{
+	struct list *p;
+
+	list_for_each(p, &m.list) {
+		struct cleanup *entry = list_entry(p, struct cleanup, link);
+		entry->func(entry->func_ctx);
+	}
+}
+
+cleanup_error_t cleanup_register(int priority,
+		cleanup_func_t func, void *func_ctx)
+{
+	struct cleanup *entry =
+		(struct cleanup *)malloc(sizeof(struct cleanup));
+
+	if (!entry) {
+		return CLEANUP_ERROR_ALLOC_FAILED;
+	}
+
+	*entry = (struct cleanup) {
+		.func = func,
+		.func_ctx = func_ctx,
+		.priority = priority,
+	};
+
+	struct list **p = &m.list.next;
+	while (*p != &m.list) {
+		struct cleanup *tmp = list_entry(*p, struct cleanup, link);
+		if (priority > tmp->priority) {
+			break;
+		}
+		p = &(*p)->next;
+	}
+	entry->link.next = *p;
+	*p = &entry->link;
+
+	return CLEANUP_ERROR_NONE;
+}
+
+cleanup_error_t cleanup_init(void)
+{
+	list_init(&m.list);
+	return CLEANUP_ERROR_NONE;
+}
+
+void cleanup_deinit(void)
+{
+	struct list *p;
+	struct list *t;
+
+	list_for_each_safe(p, t, &m.list) {
+		struct cleanup *entry = list_entry(p, struct cleanup, link);
+		list_del(p, &m.list);
+		free(entry);
+	}
+}

--- a/projects/modules.cmake
+++ b/projects/modules.cmake
@@ -3,8 +3,8 @@
 cmake_policy(SET CMP0057 NEW)
 
 if (NOT DEFINED LIBMCU_MODULES)
-	set(LIBMCU_MODULES actor ao apptimer bitmap button buzzer cli common dfu
-		jobqueue logging metrics pubsub retry runner pm fsm)
+	set(LIBMCU_MODULES actor ao apptimer bitmap button buzzer cleanup cli
+		common dfu jobqueue logging metrics pubsub retry runner pm fsm)
 endif()
 
 if (NOT "common" IN_LIST LIBMCU_MODULES)

--- a/projects/modules.mk
+++ b/projects/modules.mk
@@ -4,8 +4,8 @@ ifneq ($(LIBMCU_ROOT),)
 libmcu-basedir := $(LIBMCU_ROOT)/
 endif
 
-LIBMCU_MODULES ?= actor ao apptimer bitmap button buzzer cli common dfu \
-		  jobqueue logging metrics pubsub retry runner pm fsm
+LIBMCU_MODULES ?= actor ao apptimer bitmap button buzzer cleanup cli common \
+		  dfu jobqueue logging metrics pubsub retry runner pm fsm
 
 ifeq ($(filter common, $(LIBMCU_MODULES)),)
 LIBMCU_MODULES += common

--- a/tests/runners/cleanup/cleanup.mk
+++ b/tests/runners/cleanup/cleanup.mk
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+
+COMPONENT_NAME = Cleanup
+
+SRC_FILES = \
+	../modules/cleanup/src/cleanup.c \
+
+TEST_SRC_FILES = \
+	src/cleanup/cleanup_test.cpp \
+	src/test_all.cpp \
+
+INCLUDE_DIRS = \
+	../modules/cleanup/include \
+	../modules/common/include \
+	$(CPPUTEST_HOME)/include \
+
+MOCKS_SRC_DIRS =
+CPPUTEST_CPPFLAGS = -DUNITTEST
+
+include runners/MakefileRunner

--- a/tests/src/cleanup/cleanup_test.cpp
+++ b/tests/src/cleanup/cleanup_test.cpp
@@ -55,3 +55,14 @@ TEST(Cleanup, ShouldRegisteredFunctionsBeCalledInOrderOfPriority_WhenCleanupIsEx
 
 	cleanup_execute();
 }
+
+TEST(Cleanup, ShouldRegisteredFunctionsBeCalledInFirstComeFirstServeOrder_WhenTheSamePriorityGiven) {
+	mock().strictOrder();
+	mock().expectOneCall("test_func1");
+	mock().expectOneCall("test_func2");
+
+	cleanup_register(1, test_func1, NULL);
+	cleanup_register(1, test_func2, NULL);
+
+	cleanup_execute();
+}

--- a/tests/src/cleanup/cleanup_test.cpp
+++ b/tests/src/cleanup/cleanup_test.cpp
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "CppUTest/TestHarness.h"
+#include "CppUTest/TestHarness_c.h"
+#include "CppUTestExt/MockSupport.h"
+
+#include "libmcu/cleanup.h"
+
+TEST_GROUP(Cleanup) {
+	void setup(void) {
+		cleanup_init();
+	}
+	void teardown(void) {
+		mock().checkExpectations();
+		mock().clear();
+
+		cleanup_deinit();
+	}
+};
+
+static void test_func1(void *ctx) {
+	mock().actualCall(__func__);
+}
+
+static void test_func2(void *ctx) {
+	mock().actualCall(__func__);
+}
+
+TEST(Cleanup, ShouldReturnNoError_WhenValidFunctionIsRegistered) {
+	LONGS_EQUAL(CLEANUP_ERROR_NONE, cleanup_register(1, test_func1, NULL));
+	LONGS_EQUAL(CLEANUP_ERROR_NONE, cleanup_register(2, test_func2, NULL));
+}
+
+TEST(Cleanup, ShouldRegisteredFunctionsBeCalled_WhenCleanupIsExecuted) {
+	mock().expectOneCall("test_func1");
+	mock().expectOneCall("test_func2");
+
+	cleanup_register(1, test_func1, NULL);
+	cleanup_register(2, test_func2, NULL);
+
+	cleanup_execute();
+}
+
+TEST(Cleanup, ShouldRegisteredFunctionsBeCalledInOrderOfPriority_WhenCleanupIsExecuted) {
+	mock().strictOrder();
+	mock().expectOneCall("test_func2");
+	mock().expectOneCall("test_func1");
+
+	cleanup_register(1, test_func1, NULL);
+	cleanup_register(2, test_func2, NULL);
+
+	cleanup_execute();
+}


### PR DESCRIPTION
This pull request introduces a new `cleanup` module and integrates it into the project. The changes include adding the module to various build configuration files, implementing the module's functionality, and creating tests for it.

### New Cleanup Module Implementation:

* [`modules/cleanup/include/libmcu/cleanup.h`](diffhunk://#diff-409e699ad4d003fe9a164650f21948473c8f9fb8802bb3d13f2148d9ed0e31c1R1-R65): Added the header file for the cleanup module, defining the API and necessary data structures.
* [`modules/cleanup/src/cleanup.c`](diffhunk://#diff-64019b006478d0aff028a114f0ef4299db5b38172024dc1875776975d07c6bb2R1-R82): Implemented the cleanup module, including functions for initialization, registration, and execution of cleanup tasks.

### Build Configuration Updates:

* [`projects/modules.cmake`](diffhunk://#diff-df835517b29756741e31be696c764f72041689c67adca806aa2508caecf69df0L6-R7): Added the `cleanup` module to the list of modules in the CMake configuration.
* [`projects/modules.mk`](diffhunk://#diff-d0f579646be3e5119f5c9fe335072f802b28b2f76be1af8f250683211445117aL7-R8): Updated the Makefile to include the `cleanup` module.

### Documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R24): Added an entry for the `cleanup` module in the list of available modules.

### Testing:

* [`tests/runners/cleanup/cleanup.mk`](diffhunk://#diff-88df97e0f77458e4de2b9ab94d1d6330fc61913ee96668fa00cef2cd18c3db04R1-R20): Added a Makefile for running tests on the `cleanup` module.
* [`tests/src/cleanup/cleanup_test.cpp`](diffhunk://#diff-a77fba32e73a2a79be8b67a389335d7e2eaf4508944ff5bcbef2dac8b36de706R1-R57): Implemented unit tests for the `cleanup` module to ensure its functionality.