### PR TITLE
timer: rename timer to apptmr to avoid posix timer conflict

### DIFF
--- a/interfaces/timer/include/libmcu/timer.h
+++ b/interfaces/timer/include/libmcu/timer.h
@@ -14,40 +14,40 @@ extern "C" {
 #include <stdint.h>
 #include <stdbool.h>
 
-struct timer;
+struct apptmr;
 
-typedef void (*timer_callback_t)(struct timer *self, void *ctx);
+typedef void (*apptmr_callback_t)(struct apptmr *self, void *ctx);
 
-struct timer_api {
-	int (*enable)(struct timer *self);
-	int (*disable)(struct timer *self);
-	int (*start)(struct timer *self, uint32_t timeout_ms);
-	int (*restart)(struct timer *self, uint32_t timeout_ms);
-	int (*stop)(struct timer *self);
+struct apptmr_api {
+	int (*enable)(struct apptmr *self);
+	int (*disable)(struct apptmr *self);
+	int (*start)(struct apptmr *self, uint32_t timeout_ms);
+	int (*restart)(struct apptmr *self, uint32_t timeout_ms);
+	int (*stop)(struct apptmr *self);
 };
 
-static inline int timer_enable(struct timer *self) {
-	return ((struct timer_api *)self)->enable(self);
+static inline int apptmr_enable(struct apptmr *self) {
+	return ((struct apptmr_api *)self)->enable(self);
 }
 
-static inline int timer_disable(struct timer *self) {
-	return ((struct timer_api *)self)->disable(self);
+static inline int apptmr_disable(struct apptmr *self) {
+	return ((struct apptmr_api *)self)->disable(self);
 }
 
-static inline int timer_start(struct timer *self, uint32_t timeout_ms) {
-	return ((struct timer_api *)self)->start(self, timeout_ms);
+static inline int apptmr_start(struct apptmr *self, uint32_t timeout_ms) {
+	return ((struct apptmr_api *)self)->start(self, timeout_ms);
 }
 
-static inline int timer_restart(struct timer *self, uint32_t timeout_ms) {
-	return ((struct timer_api *)self)->restart(self, timeout_ms);
+static inline int apptmr_restart(struct apptmr *self, uint32_t timeout_ms) {
+	return ((struct apptmr_api *)self)->restart(self, timeout_ms);
 }
 
-static inline int timer_stop(struct timer *self) {
-	return ((struct timer_api *)self)->stop(self);
+static inline int apptmr_stop(struct apptmr *self) {
+	return ((struct apptmr_api *)self)->stop(self);
 }
 
-struct timer *timer_create(bool periodic, timer_callback_t callback, void *arg);
-int timer_delete(struct timer *self);
+struct apptmr *apptmr_create(bool periodic, apptmr_callback_t cb, void *cb_ctx);
+int apptmr_delete(struct apptmr *self);
 
 #if defined(__cplusplus)
 }

--- a/modules/buzzer/src/buzzer.c
+++ b/modules/buzzer/src/buzzer.c
@@ -24,13 +24,13 @@ static struct buzzer {
 	void *callback_ctx;
 
 	struct pwm_channel *pwm;
-	struct timer *timer;
+	struct apptmr *timer;
 
 	sem_t lock;
 	bool enabled;
 } m;
 
-static void on_timeout(struct timer *timer, void *arg)
+static void on_timeout(struct apptmr *timer, void *arg)
 {
 	struct buzzer *buzzer = (struct buzzer *)arg;
 	struct playing *playing = &buzzer->playing;
@@ -66,12 +66,12 @@ static void on_timeout(struct timer *timer, void *arg)
 				pitch);
 	}
 
-	timer_start(timer, tone->len_ms);
+	apptmr_start(timer, tone->len_ms);
 }
 
 static void play(struct buzzer *buzzer, const struct melody *melody)
 {
-	timer_stop(buzzer->timer);
+	apptmr_stop(buzzer->timer);
 	pwm_stop(buzzer->pwm);
 
 	buzzer->playing.melody = melody;
@@ -81,7 +81,7 @@ static void play(struct buzzer *buzzer, const struct melody *melody)
 	tone_pitch_t pitch = tone_get(tone->note, tone->octave);
 	pwm_start(buzzer->pwm, pitch, PWM_PCT_TO_MILLI(50));
 
-	timer_start(buzzer->timer, tone->len_ms);
+	apptmr_start(buzzer->timer, tone->len_ms);
 }
 
 void buzzer_play(const struct melody *melody)
@@ -127,9 +127,9 @@ void buzzer_init(struct pwm_channel *pwm,
 	m.callback_ctx = on_event_ctx;
 
 	m.pwm = pwm;
-	m.timer = timer_create(false, on_timeout, &m);
+	m.timer = apptmr_create(false, on_timeout, &m);
 
 	pwm_enable(m.pwm);
-	timer_enable(m.timer);
+	apptmr_enable(m.timer);
 	m.enabled = true;
 }

--- a/tests/mocks/timer.cpp
+++ b/tests/mocks/timer.cpp
@@ -1,45 +1,45 @@
 #include "CppUTestExt/MockSupport.h"
-#include "libmcu/timer.h"
+#include "libmcu/apptmr.h"
 
-struct timer {
-	struct timer_api api;
+struct apptmr {
+	struct apptmr_api api;
 };
 
-static int enable(struct timer *self) {
-	return mock().actualCall("timer_enable")
+static int enable(struct apptmr *self) {
+	return mock().actualCall("apptmr_enable")
 		.withParameter("self", self)
 		.returnIntValue();
 }
 
-static int disable(struct timer *self) {
-	return mock().actualCall("timer_disable")
+static int disable(struct apptmr *self) {
+	return mock().actualCall("apptmr_disable")
 		.withParameter("self", self)
 		.returnIntValue();
 }
 
-static int start(struct timer *self, uint32_t timeout_ms) {
-	return mock().actualCall("timer_start")
-		.withParameter("self", self)
-		.withParameter("timeout_ms", timeout_ms)
-		.returnIntValue();
-}
-
-static int restart(struct timer *self, uint32_t timeout_ms) {
-	return mock().actualCall("timer_restart")
+static int start(struct apptmr *self, uint32_t timeout_ms) {
+	return mock().actualCall("apptmr_start")
 		.withParameter("self", self)
 		.withParameter("timeout_ms", timeout_ms)
 		.returnIntValue();
 }
 
-static int stop(struct timer *self) {
-	return mock().actualCall("timer_stop")
+static int restart(struct apptmr *self, uint32_t timeout_ms) {
+	return mock().actualCall("apptmr_restart")
+		.withParameter("self", self)
+		.withParameter("timeout_ms", timeout_ms)
+		.returnIntValue();
+}
+
+static int stop(struct apptmr *self) {
+	return mock().actualCall("apptmr_stop")
 		.withParameter("self", self)
 		.returnIntValue();
 }
 
-struct timer *timer_create(bool periodic, timer_callback_t callback, void *arg)
+struct apptmr *apptmr_create(bool periodic, apptmr_callback_t cb, void *cb_ctx)
 {
-	struct timer *self = new struct timer;
+	struct apptmr *self = new struct apptmr;
 	self->api.enable = enable;
 	self->api.disable = disable;
 	self->api.start = start;
@@ -48,7 +48,7 @@ struct timer *timer_create(bool periodic, timer_callback_t callback, void *arg)
 	return self;
 }
 
-int timer_delete(struct timer *self)
+int apptmr_delete(struct apptmr *self)
 {
 	delete self;
 	return 0;


### PR DESCRIPTION
This pull request involves renaming the `timer` structure and related functions to `apptmr` across multiple files to improve clarity and consistency. Below is a summary of the most important changes:

### Changes in `libmcu/timer.h`:

* Renamed `struct timer` to `struct apptmr` and updated all associated typedefs and function signatures.

### Changes in `modules/buzzer/src/buzzer.c`:

* Updated references from `struct timer` to `struct apptmr` and changed function calls accordingly. [[1]](diffhunk://#diff-0d9d2edb2ec30d199b71f27d61489db04f1d2c26ff5d9f2983d751e901b20c54L27-R33) [[2]](diffhunk://#diff-0d9d2edb2ec30d199b71f27d61489db04f1d2c26ff5d9f2983d751e901b20c54L69-R74) [[3]](diffhunk://#diff-0d9d2edb2ec30d199b71f27d61489db04f1d2c26ff5d9f2983d751e901b20c54L84-R84) [[4]](diffhunk://#diff-0d9d2edb2ec30d199b71f27d61489db04f1d2c26ff5d9f2983d751e901b20c54L130-R133)

### Changes in `ports/esp-idf/timer.c`:

* Renamed `struct timer` to `struct apptmr` and updated all related function definitions and calls. [[1]](diffhunk://#diff-4d86c507d45d70883d1b35f16cda8dbb8a61aacaa6a9d16bcf60d144a339bd5eL15-R26) [[2]](diffhunk://#diff-4d86c507d45d70883d1b35f16cda8dbb8a61aacaa6a9d16bcf60d144a339bd5eL37-R51) [[3]](diffhunk://#diff-4d86c507d45d70883d1b35f16cda8dbb8a61aacaa6a9d16bcf60d144a339bd5eL65-R122)

### Changes in `tests/mocks/timer.cpp`:

* Renamed `struct timer` to `struct apptmr` and updated mock functions to reflect the new naming convention. [[1]](diffhunk://#diff-772016c5b25a138863c1bd30403f52bc732b7b5ea438eeaf5917ad4f86949adcL2-R42) [[2]](diffhunk://#diff-772016c5b25a138863c1bd30403f52bc732b7b5ea438eeaf5917ad4f86949adcL51-R51)