### PR TITLE
wdt: add enable/disable functions

### DIFF
--- a/interfaces/wdt/include/libmcu/wdt.h
+++ b/interfaces/wdt/include/libmcu/wdt.h
@@ -45,6 +45,31 @@ int wdt_init(void);
 void wdt_deinit(void);
 
 /**
+ * @brief Enable the watchdog timer.
+ *
+ * This function enables the watchdog timer for the specified instance.
+ * Once enabled, the watchdog timer will start monitoring the system and
+ * will trigger a timeout if not fed within the specified period.
+ *
+ * @param[in] self Pointer to the watchdog timer instance.
+ *
+ * @return 0 on success, negative error code on failure.
+ */
+int wdt_enable(struct wdt *self);
+
+/**
+ * @brief Disable the watchdog timer.
+ *
+ * This function disables the watchdog timer for the specified instance.
+ * Once disabled, the watchdog timer will stop monitoring the system and
+ * will not trigger a timeout.
+ *
+ * @param[in] self Pointer to the watchdog timer instance.
+ * @return 0 on success, negative error code on failure.
+ */
+int wdt_disable(struct wdt *self);
+
+/**
  * @brief Register a callback function for watchdog timeout.
  *
  * This function registers a callback function that will be called when the
@@ -65,19 +90,21 @@ int wdt_register_timeout_cb(wdt_timeout_cb_t cb, void *cb_ctx);
 /**
  * @brief Create a new watchdog timer instance.
  *
- * @param[in] period_ms The timeout period in milliseconds for the watchdog
- *                      timer.
- * @param[in] cb Callback function to be called on watchdog timeout.
- * @param[in] cb_ctx User-defined context to be passed to the callback function.
+ * This function creates a new watchdog timer instance with the specified name,
+ * timeout period, and callback function. The watchdog timer will trigger the
+ * callback function if the timeout period elapses without being reset.
  *
- * @note The callback registered here will be called when this watchdog timer
- *       times out and then the callback registered in wdt_init() will be
- *       called.
+ * @param[in] name The name of the watchdog timer instance.
+ * @param[in] period_ms The timeout period in milliseconds.
+ * @param[in] cb The callback function to be called when the timeout period
+ *            elapses.
+ * @param[in] cb_ctx A user-defined context pointer that will be passed to
+ *            the callback function.
  *
- * @return Pointer to the newly created watchdog timer instance,
- *                 or NULL on failure.
+ * @return A pointer to the newly created watchdog timer instance,
+ *         or NULL on failure.
  */
-struct wdt *wdt_new(const uint32_t period_ms,
+struct wdt *wdt_new(const char *name, const uint32_t period_ms,
 		wdt_timeout_cb_t cb, void *cb_ctx);
 
 /**

--- a/modules/fsm/src/fsm.c
+++ b/modules/fsm/src/fsm.c
@@ -6,8 +6,8 @@
 
 #include "libmcu/fsm.h"
 
-#if !defined(FSM_DEBUG)
-#define FSM_DEBUG(...)
+#if !defined(FSM_INFO)
+#define FSM_INFO(...)
 #endif
 
 static bool process(const struct fsm_item *item,
@@ -25,9 +25,13 @@ static bool process(const struct fsm_item *item,
 			(*item->action.run)(current_state, next_candidate, ctx);
 		}
 
-		FSM_DEBUG("FSM state change from %d to %d",
-				current_state, next_candidate);
-		*next_state = next_candidate;
+		if (current_state != next_candidate) {
+			*next_state = next_candidate;
+
+			FSM_INFO("FSM state change from %d to %d",
+					current_state, next_candidate);
+		}
+
 		return true;
 	}
 

--- a/tests/stubs/wdt.cpp
+++ b/tests/stubs/wdt.cpp
@@ -4,13 +4,24 @@ struct wdt {
 	int dummy;
 };
 
-struct wdt *wdt_new(const uint32_t period_ms, wdt_timeout_cb_t cb, void *cb_ctx) {
+struct wdt *wdt_new(const char *name, const uint32_t period_ms,
+		wdt_timeout_cb_t cb, void *cb_ctx) {
 	static struct wdt wdt;
 	return &wdt;
 }
 
 void wdt_delete(struct wdt *self) {
 	(void)self;
+}
+
+int wdt_enable(struct wdt *self) {
+	(void)self;
+	return 0;
+}
+
+int wdt_disable(struct wdt *self) {
+	(void)self;
+	return 0;
 }
 
 int wdt_register_timeout_cb(wdt_timeout_cb_t cb, void *cb_ctx) {


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the watchdog timer (WDT) functionality. The main changes include adding enable/disable functions, updating the `wdt_new` function to include names for instances, and improving logging and timeout checks.

### Enhancements to WDT functionality:

* Added `wdt_enable` and `wdt_disable` functions to allow enabling and disabling the watchdog timer. (`interfaces/wdt/include/libmcu/wdt.h`, `ports/esp-idf/wdt.c`, `tests/stubs/wdt.cpp`) [[1]](diffhunk://#diff-032b2570ef43cb2b2670d62de7dd2fb6afae8995372bf444b6e1b2f3ba6abab0R47-R71) [[2]](diffhunk://#diff-73dff416cfe64f39bc8a2a9aca2f934e745ff0577114f6ba95082d0640576844L102-R129) [[3]](diffhunk://#diff-093b7d852335938e785c0a745eb4edac2ecc9454dc523b88c5bedadc73cb1738R17-R26)
* Modified the `wdt_new` function to include a name parameter for the watchdog timer instance. (`interfaces/wdt/include/libmcu/wdt.h`, `ports/esp-idf/wdt.c`, `tests/stubs/wdt.cpp`) [[1]](diffhunk://#diff-032b2570ef43cb2b2670d62de7dd2fb6afae8995372bf444b6e1b2f3ba6abab0L68-R107) [[2]](diffhunk://#diff-73dff416cfe64f39bc8a2a9aca2f934e745ff0577114f6ba95082d0640576844R31-R40) [[3]](diffhunk://#diff-093b7d852335938e785c0a745eb4edac2ecc9454dc523b88c5bedadc73cb1738L7-R8)

### Logging and timeout improvements:

* Added logging for watchdog timer timeouts using the `WDT_INFO` macro. (`ports/esp-idf/wdt.c`) [[1]](diffhunk://#diff-73dff416cfe64f39bc8a2a9aca2f934e745ff0577114f6ba95082d0640576844R18-R21) [[2]](diffhunk://#diff-73dff416cfe64f39bc8a2a9aca2f934e745ff0577114f6ba95082d0640576844R90)
* Updated the timeout check to ensure it only occurs when the watchdog timer is enabled. (`ports/esp-idf/wdt.c`)

### Codebase maintenance:

* Included the `<stdbool.h>` header for boolean type usage. (`ports/esp-idf/wdt.c`)