### PR TITLE
chore/test: add new mock and stub functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Any feedback would be appreciated.
 * [KVStore](interfaces/kvstore)
 * [PWM](interfaces/pwm)
 * [SPI](interfaces/spi)
-* [Timer](interfaces/timer)
+* [Application Timer](interfaces/apptmr)
 * [UART](interfaces/uart)
 * [WDT](interfaces/wdt)
 * [WiFi](interfaces/wifi)

--- a/interfaces/apptmr/include/libmcu/apptmr.h
+++ b/interfaces/apptmr/include/libmcu/apptmr.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-#ifndef LIBMCU_TIMER_H
-#define LIBMCU_TIMER_H
+#ifndef LIBMCU_APPTMR_H
+#define LIBMCU_APPTMR_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -24,6 +24,7 @@ struct apptmr_api {
 	int (*start)(struct apptmr *self, uint32_t timeout_ms);
 	int (*restart)(struct apptmr *self, uint32_t timeout_ms);
 	int (*stop)(struct apptmr *self);
+	void (*trigger)(struct apptmr *self);
 };
 
 static inline int apptmr_enable(struct apptmr *self) {
@@ -46,11 +47,17 @@ static inline int apptmr_stop(struct apptmr *self) {
 	return ((struct apptmr_api *)self)->stop(self);
 }
 
+static inline void apptmr_trigger(struct apptmr *self) {
+	((struct apptmr_api *)self)->trigger(self);
+}
+
 struct apptmr *apptmr_create(bool periodic, apptmr_callback_t cb, void *cb_ctx);
 int apptmr_delete(struct apptmr *self);
+
+void apptmr_create_hook(struct apptmr *self);
 
 #if defined(__cplusplus)
 }
 #endif
 
-#endif /* LIBMCU_TIMER_H */
+#endif /* LIBMCU_APPTMR_H */

--- a/modules/buzzer/src/buzzer.c
+++ b/modules/buzzer/src/buzzer.c
@@ -10,7 +10,7 @@
 #include <stdint.h>
 #include <semaphore.h>
 
-#include "libmcu/timer.h"
+#include "libmcu/apptmr.h"
 
 struct playing {
 	const struct melody *melody;

--- a/ports/esp-idf/apptmr.c
+++ b/ports/esp-idf/apptmr.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: MIT
  */
 
-#include "libmcu/timer.h"
+#include "libmcu/apptmr.h"
 #include <string.h>
 #include "esp_timer.h"
 
-#if !defined(TIMER_MAX)
-#define TIMER_MAX			8
+#if !defined(APPTMR_MAX)
+#define APPTMR_MAX			8
 #endif
 
 struct apptmr {
@@ -46,6 +46,11 @@ static void callback_wrapper(void *arg)
 	if (p && p->callback) {
 		(*p->callback)(p, p->arg);
 	}
+}
+
+static void trigger(struct apptmr *self)
+{
+	callback_wrapper(self);
 }
 
 static int start_apptmr(struct apptmr *self, uint32_t timeout_ms)
@@ -85,8 +90,8 @@ static int disable_apptmr(struct apptmr *self)
 
 struct apptmr *apptmr_create(bool periodic, apptmr_callback_t cb, void *cb_ctx)
 {
-	static struct apptmr apptmrs[TIMER_MAX];
-	struct apptmr *apptmr = new_apptmr(apptmrs, TIMER_MAX);
+	static struct apptmr apptmrs[APPTMR_MAX];
+	struct apptmr *apptmr = new_apptmr(apptmrs, APPTMR_MAX);
 
 	if (apptmr) {
 		*apptmr = (struct apptmr) {
@@ -96,6 +101,7 @@ struct apptmr *apptmr_create(bool periodic, apptmr_callback_t cb, void *cb_ctx)
 				.start = start_apptmr,
 				.restart = restart_apptmr,
 				.stop = stop_apptmr,
+				.trigger = trigger,
 			},
 
 			.callback = cb,

--- a/projects/interfaces.cmake
+++ b/projects/interfaces.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 if (NOT DEFINED LIBMCU_INTERFACES)
-	set(LIBMCU_INTERFACES adc ble flash gpio i2c kvstore l4 pwm spi timer uart wdt wifi)
+	set(LIBMCU_INTERFACES adc apptmr ble flash gpio i2c kvstore l4 pwm spi uart wdt wifi)
 endif()
 
 foreach(iface ${LIBMCU_INTERFACES})

--- a/projects/interfaces.mk
+++ b/projects/interfaces.mk
@@ -4,7 +4,7 @@ ifneq ($(LIBMCU_ROOT),)
 libmcu-basedir := $(LIBMCU_ROOT)/
 endif
 
-LIBMCU_INTERFACES ?= adc ble flash gpio i2c kvstore l4 pwm spi timer uart wdt wifi
+LIBMCU_INTERFACES ?= adc apptmr ble flash gpio i2c kvstore l4 pwm spi uart wdt wifi
 
 LIBMCU_INTERFACES_INCS := $(foreach d, $(LIBMCU_INTERFACES), \
 	$(addprefix $(libmcu-basedir)interfaces/, $(d))/include)

--- a/tests/mocks/apptmr.cpp
+++ b/tests/mocks/apptmr.cpp
@@ -1,8 +1,10 @@
 #include "CppUTestExt/MockSupport.h"
-#include "libmcu/timer.h"
+#include "libmcu/apptmr.h"
 
 struct apptmr {
 	struct apptmr_api api;
+	apptmr_callback_t cb;
+	void *cb_ctx;
 };
 
 static int enable(struct apptmr *self) {
@@ -37,6 +39,13 @@ static int stop(struct apptmr *self) {
 		.returnIntValue();
 }
 
+static void trigger(struct apptmr *self)
+{
+	if (self->cb) {
+		(*self->cb)(self, self->cb_ctx);
+	}
+}
+
 struct apptmr *apptmr_create(bool periodic, apptmr_callback_t cb, void *cb_ctx)
 {
 	struct apptmr *self = new struct apptmr;
@@ -45,6 +54,10 @@ struct apptmr *apptmr_create(bool periodic, apptmr_callback_t cb, void *cb_ctx)
 	self->api.start = start;
 	self->api.restart = restart;
 	self->api.stop = stop;
+	self->api.trigger = trigger;
+	self->cb = cb;
+	self->cb_ctx = cb_ctx;
+	apptmr_create_hook(self);
 	return self;
 }
 

--- a/tests/mocks/board.cpp
+++ b/tests/mocks/board.cpp
@@ -12,3 +12,11 @@ uint64_t board_get_time_since_boot_us(void) {
 void board_reboot(void) {
 	mock().actualCall(__func__);
 }
+
+uint32_t board_random(void) {
+	return mock().actualCall(__func__).returnUnsignedIntValue();
+}
+
+unsigned long board_get_current_stack_watermark(void) {
+	return mock().actualCall(__func__).returnUnsignedIntValue();
+}

--- a/tests/mocks/timer.cpp
+++ b/tests/mocks/timer.cpp
@@ -1,5 +1,5 @@
 #include "CppUTestExt/MockSupport.h"
-#include "libmcu/apptmr.h"
+#include "libmcu/timer.h"
 
 struct apptmr {
 	struct apptmr_api api;

--- a/tests/mocks/timext.cpp
+++ b/tests/mocks/timext.cpp
@@ -9,3 +9,8 @@ void timeout_set(unsigned long *goal, unsigned long msec) {
 	mock().actualCall(__func__)
 		.withParameter("msec", msec);
 }
+
+void sleep_ms(unsigned long msec) {
+	mock().actualCall(__func__)
+		.withParameter("msec", msec);
+}

--- a/tests/stubs/apptmr.cpp
+++ b/tests/stubs/apptmr.cpp
@@ -1,0 +1,56 @@
+#include "CppUTestExt/MockSupport.h"
+#include "libmcu/apptmr.h"
+
+struct apptmr {
+	struct apptmr_api api;
+	apptmr_callback_t cb;
+	void *cb_ctx;
+};
+
+static int enable(struct apptmr *self) {
+	return 0;
+}
+
+static int disable(struct apptmr *self) {
+	return 0;
+}
+
+static int start(struct apptmr *self, uint32_t timeout_ms) {
+	return 0;
+}
+
+static int restart(struct apptmr *self, uint32_t timeout_ms) {
+	return 0;
+}
+
+static int stop(struct apptmr *self) {
+	return 0;
+}
+
+static void trigger(struct apptmr *self)
+{
+	if (self->cb) {
+		(*self->cb)(self, self->cb_ctx);
+	}
+}
+
+struct apptmr *apptmr_create(bool periodic, apptmr_callback_t cb, void *cb_ctx)
+{
+	struct apptmr *self = new struct apptmr;
+	self->api.enable = enable;
+	self->api.disable = disable;
+	self->api.start = start;
+	self->api.restart = restart;
+	self->api.stop = stop;
+	self->api.trigger = trigger;
+	self->cb = cb;
+	self->cb_ctx = cb_ctx;
+	apptmr_create_hook(self);
+	return self;
+}
+
+int apptmr_delete(struct apptmr *self)
+{
+	delete self;
+	return 0;
+}

--- a/tests/stubs/board.cpp
+++ b/tests/stubs/board.cpp
@@ -12,3 +12,11 @@ uint64_t board_get_time_since_boot_us(void) {
 void board_reboot(void) {
 	return;
 }
+
+uint32_t board_random(void) {
+	return 0;
+}
+
+unsigned long board_get_current_stack_watermark(void) {
+	return 0;
+}


### PR DESCRIPTION
This pull request includes several changes to the mock and stub implementations of board and timer functions. The most important changes are the addition of new mock functions and the inclusion of a different header file for the timer mock.

Changes to mock implementations:

* [`tests/mocks/board.cpp`](diffhunk://#diff-ad7a39c5ce19b835b2c96270b93d48f09ab3a267c8c8c7f54bbdf892d0a869a4R15-R22): Added mock functions `board_random` and `board_get_current_stack_watermark`.
* [`tests/mocks/timext.cpp`](diffhunk://#diff-e1fa4cc3cb175d5566419288de235801610e5e9e5ee12f4239f9fd5181cc1cb7R12-R16): Added mock function `sleep_ms`.

Changes to stub implementations:

* [`tests/stubs/board.cpp`](diffhunk://#diff-b4af2c9da4052f8fda5e91ee45617b369c79b030559e5c0c45307305e4e63271R15-R22): Added stub functions `board_random` and `board_get_current_stack_watermark`.

Changes to header file inclusion:

* [`tests/mocks/timer.cpp`](diffhunk://#diff-772016c5b25a138863c1bd30403f52bc732b7b5ea438eeaf5917ad4f86949adcL2-R2): Changed included header file from `libmcu/apptmr.h` to `libmcu/timer.h`.