### PR TITLE
test/actor: fix task syncronization, resulting in test hang

### DIFF
--- a/tests/src/actor/actor_test.cpp
+++ b/tests/src/actor/actor_test.cpp
@@ -60,10 +60,7 @@ TEST_GROUP(ACTOR) {
 		actor_init(msgbuf, sizeof(msgbuf), 4096UL);
 	}
 	void teardown(void) {
-                /* give some time space for new threads to take place to run
-                 * before killed */
                 actor_deinit();
-                usleep(100);
 		sem_destroy(&done);
 
 		mock().checkExpectations();

--- a/tests/src/actor/actor_timer_test.cpp
+++ b/tests/src/actor/actor_timer_test.cpp
@@ -63,10 +63,6 @@ TEST_GROUP(ACTOR_TIMER) {
 	}
 	void teardown(void) {
                 actor_deinit();
-                /* FIXME: without the delay, the test sometimes goes hang in the
-                 * github action. It seems like the newly created thread doesn't
-                 * get the semaphore even though it's posted by actor_timer. */
-                usleep(100);
 		sem_destroy(&done);
 		pthread_mutex_destroy(&lock);
 


### PR DESCRIPTION
This pull request makes several important changes to the `modules/actor/src/actor.c` file to improve thread management and synchronization. Additionally, it updates the test files to remove unnecessary delays. The most important changes include adding new semaphores for better control of thread states, modifying the dispatcher function to use these semaphores, and updating the initialization and deinitialization functions accordingly.

### Thread Management Improvements:
* [`modules/actor/src/actor.c`](diffhunk://#diff-9c7a1cabbfe4f8a57a0b548fe3667fdfa63706e674f0f009057488ae4d9e176bR63-R68): Added `sem_t ready` and `sem_t terminated` semaphores to the `core` struct to manage thread readiness and termination. Also added a `bool running` flag to indicate the running state of the thread.
* [`modules/actor/src/actor.c`](diffhunk://#diff-9c7a1cabbfe4f8a57a0b548fe3667fdfa63706e674f0f009057488ae4d9e176bR181-R193): Modified the `dispatcher` function to set the `running` flag to true, post the `ready` semaphore, and use the `running` flag in the while loop condition. Added posting to the `terminated` semaphore before returning.
* [`modules/actor/src/actor.c`](diffhunk://#diff-9c7a1cabbfe4f8a57a0b548fe3667fdfa63706e674f0f009057488ae4d9e176bR203-R206): Updated the `initialize_scheduler` function to initialize the new `ready` and `terminated` semaphores.
* [`modules/actor/src/actor.c`](diffhunk://#diff-9c7a1cabbfe4f8a57a0b548fe3667fdfa63706e674f0f009057488ae4d9e176bL223-R246): Updated the `deinitialize_scheduler` function to wait for the `ready` semaphore before destroying the dispatcher thread, set the `running` flag to false, post the `dispatch_event` semaphore, and wait for the `terminated` semaphore before destroying the semaphores.

### Test Updates:
* `tests/src/actor/actor_test.cpp` and `tests/src/actor/actor_timer_test.cpp`: Removed `usleep(100)` calls in the `teardown` functions as the new semaphore logic ensures proper synchronization without needing a delay. [[1]](diffhunk://#diff-768dbd20700cf2885b2e73528f205820f85bdf088b15933d9a2130531002a3edL63-L66) [[2]](diffhunk://#diff-02de3cd0d8e4eeb64f6e67f28766be932e986a761598826637a49e3ddbe79606L66-L69)