### PR TITLE
fsm: change to call the action only after a state transition is completed

### DIFF
--- a/modules/fsm/src/fsm.c
+++ b/modules/fsm/src/fsm.c
@@ -21,15 +21,15 @@ static bool process(const struct fsm_item *item,
 	fsm_state_t next_candidate = item->state.next;
 
 	if (item->event && (*item->event)(current_state, next_candidate, ctx)) {
-		if (item->action.run) {
-			(*item->action.run)(current_state, next_candidate, ctx);
-		}
-
 		if (current_state != next_candidate) {
 			*next_state = next_candidate;
 
 			FSM_INFO("FSM state change from %d to %d",
 					current_state, next_candidate);
+		}
+
+		if (item->action.run) {
+			(*item->action.run)(current_state, next_candidate, ctx);
 		}
 
 		return true;


### PR DESCRIPTION
This pull request includes a change to the `process` function in the `fsm.c` file to modify the order of execution for the action run method.

Reordering of function calls:

* [`modules/fsm/src/fsm.c`](diffhunk://#diff-d29a53c47d361e7f4d2952555b26998859db1bca461e3298534d03d9b1539cc0L24-R34): Moved the `item->action.run` function call to occur after the state change check, ensuring that the action is executed only after a state transition is confirmed.