### PR TITLE
fsm: return new state from fsm_step function

### DIFF
--- a/modules/fsm/include/libmcu/fsm.h
+++ b/modules/fsm/include/libmcu/fsm.h
@@ -62,11 +62,17 @@ void fsm_init(struct fsm *fsm,
 		const struct fsm_item *items, size_t item_len, void *ctx);
 
 /**
- * @brief Perform a step in the FSM, transitioning between states if needed.
+ * @brief Perform a single step in the finite state machine.
  *
- * @param[in] fsm Pointer to the FSM structure.
+ * This function advances the finite state machine (FSM) by one step,
+ * transitioning to the next state based on the current state and the
+ * defined state transitions.
+ *
+ * @param[in] fsm A pointer to the finite state machine structure.
+ *
+ * @return The new state of the finite state machine after the step.
  */
-void fsm_step(struct fsm *fsm);
+fsm_state_t fsm_step(struct fsm *fsm);
 
 /**
  * @brief Reset the FSM to its initial state.

--- a/modules/fsm/src/fsm.c
+++ b/modules/fsm/src/fsm.c
@@ -38,7 +38,7 @@ static bool process(const struct fsm_item *item,
 	return false;
 }
 
-void fsm_step(struct fsm *fsm)
+fsm_state_t fsm_step(struct fsm *fsm)
 {
 	fsm_state_t current_state = fsm->state.present;
 
@@ -49,6 +49,8 @@ void fsm_step(struct fsm *fsm)
 			break;
 		}
 	}
+
+	return fsm->state.present;
 }
 
 fsm_state_t fsm_state(const struct fsm *fsm)


### PR DESCRIPTION
This pull request makes several important changes to the finite state machine (FSM) implementation in the `libmcu` library. The changes primarily focus on improving the `fsm_step` function by modifying its return type and enhancing its documentation.

Enhancements to FSM functionality:

* [`modules/fsm/include/libmcu/fsm.h`](diffhunk://#diff-921d067689e0987308aaf2b52ee98e07c9d217f8fd9b3a5d818b077afb0b51cdL65-R75): Updated the `fsm_step` function to return the new state of the FSM after a step, and improved the function's documentation to clarify its behavior.

* [`modules/fsm/src/fsm.c`](diffhunk://#diff-d29a53c47d361e7f4d2952555b26998859db1bca461e3298534d03d9b1539cc0L41-R41): Modified the `fsm_step` function to return the current state of the FSM after processing a step. This change aligns with the updated function signature in the header file. [[1]](diffhunk://#diff-d29a53c47d361e7f4d2952555b26998859db1bca461e3298534d03d9b1539cc0L41-R41) [[2]](diffhunk://#diff-d29a53c47d361e7f4d2952555b26998859db1bca461e3298534d03d9b1539cc0R52-R53)