### PR TITLE
chore/test: add timext stubs

### DIFF
--- a/tests/stubs/timext.cpp
+++ b/tests/stubs/timext.cpp
@@ -1,0 +1,6 @@
+#include "CppUTestExt/MockSupport.h"
+#include "libmcu/timext.h"
+
+void sleep_ms(unsigned long msec) {
+	(void)msec;
+}


### PR DESCRIPTION
This pull request includes a small change to the `tests/stubs/timext.cpp` file. The change adds necessary includes and a stub implementation of the `sleep_ms` function.

* [`tests/stubs/timext.cpp`](diffhunk://#diff-ca544f0741426608be36b9ecee1488d09df0ef61238b3620151819498be66dfcR1-R6): Added `#include` statements for `CppUTestExt/MockSupport.h` and `libmcu/timext.h`, and implemented a stub for the `sleep_ms` function.