### PR TITLE
port/wdt: esp-idf: add function to get watchdog timer name

### DIFF
--- a/interfaces/wdt/include/libmcu/wdt.h
+++ b/interfaces/wdt/include/libmcu/wdt.h
@@ -123,6 +123,17 @@ void wdt_delete(struct wdt *self);
  */
 int wdt_feed(struct wdt *self);
 
+/**
+ * @brief Get the name of the watchdog timer.
+ *
+ * This function returns the name of the specified watchdog timer instance.
+ *
+ * @param[in] self Pointer to the watchdog timer instance.
+ *
+ * @return The name of the watchdog timer.
+ */
+const char *wdt_name(const struct wdt *self);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/ports/esp-idf/wdt.c
+++ b/ports/esp-idf/wdt.c
@@ -153,6 +153,11 @@ int wdt_register_timeout_cb(wdt_timeout_cb_t cb, void *cb_ctx)
 	return 0;
 }
 
+const char *wdt_name(const struct wdt *self)
+{
+	return self->name;
+}
+
 int wdt_init(void)
 {
 	m.min_period_ms = CONFIG_TASK_WDT_TIMEOUT_S * 1000;


### PR DESCRIPTION
This pull request includes changes to the watchdog timer (`wdt`) module, adding a new function to retrieve the name of a watchdog timer instance.

Enhancements to watchdog timer module:

* [`interfaces/wdt/include/libmcu/wdt.h`](diffhunk://#diff-032b2570ef43cb2b2670d62de7dd2fb6afae8995372bf444b6e1b2f3ba6abab0R126-R136): Added a new function declaration `wdt_name` to get the name of the watchdog timer.
* [`ports/esp-idf/wdt.c`](diffhunk://#diff-73dff416cfe64f39bc8a2a9aca2f934e745ff0577114f6ba95082d0640576844R156-R160): Implemented the `wdt_name` function to return the name of the specified watchdog timer instance.