### PR TITLE
chore/apptmr: add doc and const qualifiers

### DIFF
--- a/interfaces/apptmr/include/libmcu/apptmr.h
+++ b/interfaces/apptmr/include/libmcu/apptmr.h
@@ -21,40 +21,144 @@ typedef void (*apptmr_callback_t)(struct apptmr *self, void *ctx);
 struct apptmr_api {
 	int (*enable)(struct apptmr *self);
 	int (*disable)(struct apptmr *self);
-	int (*start)(struct apptmr *self, uint32_t timeout_ms);
-	int (*restart)(struct apptmr *self, uint32_t timeout_ms);
+	int (*start)(struct apptmr *self, const uint32_t timeout_ms);
+	int (*restart)(struct apptmr *self, const uint32_t timeout_ms);
 	int (*stop)(struct apptmr *self);
 	void (*trigger)(struct apptmr *self);
 };
 
+/**
+ * @brief Enable the application timer.
+ *
+ * This function enables the specified application timer instance.
+ *
+ * @param[in] self Pointer to the application timer instance.
+ *
+ * @return 0 on success, negative error code on failure.
+ */
 static inline int apptmr_enable(struct apptmr *self) {
 	return ((struct apptmr_api *)self)->enable(self);
 }
 
+/**
+ * @brief Disable the application timer.
+ *
+ * This function disables the specified application timer instance.
+ *
+ * @param[in] self Pointer to the application timer instance.
+ *
+ * @return 0 on success, negative error code on failure.
+ */
 static inline int apptmr_disable(struct apptmr *self) {
 	return ((struct apptmr_api *)self)->disable(self);
 }
 
-static inline int apptmr_start(struct apptmr *self, uint32_t timeout_ms) {
+/**
+ * @brief Start the application timer.
+ *
+ * This function starts the specified application timer instance with the given timeout.
+ *
+ * @param[in] self Pointer to the application timer instance.
+ * @param[in] timeout_ms Timeout value in milliseconds.
+ * @return 0 on success, negative error code on failure.
+ */
+static inline int apptmr_start(struct apptmr *self, const uint32_t timeout_ms) {
 	return ((struct apptmr_api *)self)->start(self, timeout_ms);
 }
 
-static inline int apptmr_restart(struct apptmr *self, uint32_t timeout_ms) {
+/**
+ * @brief Restart the application timer.
+ *
+ * This function restarts the specified application timer instance with the given timeout.
+ *
+ * @param[in] self Pointer to the application timer instance.
+ * @param[in] timeout_ms Timeout value in milliseconds.
+ *
+ * @return 0 on success, negative error code on failure.
+ */
+static inline int apptmr_restart(struct apptmr *self,
+		const uint32_t timeout_ms) {
 	return ((struct apptmr_api *)self)->restart(self, timeout_ms);
 }
 
+/**
+ * @brief Stop the application timer.
+ *
+ * This function stops the specified application timer instance.
+ *
+ * @param[in] self Pointer to the application timer instance.
+ *
+ * @return 0 on success, negative error code on failure.
+ */
 static inline int apptmr_stop(struct apptmr *self) {
 	return ((struct apptmr_api *)self)->stop(self);
 }
 
+/**
+ * @brief Trigger the application timer.
+ *
+ * This function triggers the specified application timer instance.
+ *
+ * @param[in] self Pointer to the application timer instance.
+ */
 static inline void apptmr_trigger(struct apptmr *self) {
 	((struct apptmr_api *)self)->trigger(self);
 }
 
+/**
+ * @brief Create a new application timer.
+ *
+ * This function creates a new application timer instance.
+ *
+ * @param[in] periodic Boolean indicating if the timer is periodic.
+ * @param[in] cb Callback function to be called on timer events.
+ * @param[in] cb_ctx Context to be passed to the callback function.
+ *
+ * @return Pointer to the created application timer instance.
+ */
 struct apptmr *apptmr_create(bool periodic, apptmr_callback_t cb, void *cb_ctx);
+
+/**
+ * @brief Delete the application timer.
+ *
+ * This function deletes the specified application timer instance.
+ *
+ * @param[in] self Pointer to the application timer instance.
+ *
+ * @return 0 on success, negative error code on failure.
+ */
 int apptmr_delete(struct apptmr *self);
 
+/**
+ * @brief Get the application timer capacity.
+ *
+ * This function returns the number of application timers that can be created.
+ *
+ * @return The application timer capacity.
+ */
+int apptmr_cap(void);
+
+/**
+ * @brief Get the application timer length.
+ *
+ * This function returns the number of application timers that have been
+ * created.
+ *
+ * @return The application timer length.
+ */
+int apptmr_len(void);
+
+#if defined(UNIT_TEST)
+/**
+ * @brief Hook function for unit testing application timer creation.
+ *
+ * This function is used as a hook for unit tests to perform additional
+ * operations when an application timer is created.
+ *
+ * @param self Pointer to the application timer instance.
+ */
 void apptmr_create_hook(struct apptmr *self);
+#endif
 
 #if defined(__cplusplus)
 }

--- a/modules/actor/include/libmcu/actor.h
+++ b/modules/actor/include/libmcu/actor.h
@@ -33,34 +33,92 @@ struct actor {
 	int priority;
 };
 
-int actor_init(void *mem, size_t memsize, size_t stack_size_bytes);
-int actor_deinit(void);
-
-struct actor *actor_new(actor_handler_t handler, int priority);
-struct actor *actor_set(struct actor *actor,
-		actor_handler_t handler, int priority);
+/**
+ * @brief Initialize the actor system.
+ *
+ * This function initializes the actor system with the provided memory
+ * and stack size.
+ *
+ * @param[in] mem Pointer to the memory to be used by the actor system.
+ * @param[in] memsize Size of the memory in bytes.
+ * @param[in] stack_size_bytes Size of the stack for each actor in bytes.
+ *
+ * @return 0 on success, negative error code on failure.
+ */
+int actor_init(void *mem, const size_t memsize, const size_t stack_size_bytes);
 
 /**
- * @brief Send a message to an actor
+ * @brief Deinitialize the actor system.
  *
- * @param actor actor who gets the message
- * @param msg message to send
+ * This function deinitializes the actor system, releasing any resources
+ * that were allocated.
  *
- * @return 0 on success otherwise error
+ * @return 0 on success, negative error code on failure.
+ */
+int actor_deinit(void);
+
+/**
+ * @brief Create a new actor.
+ *
+ * This function creates a new actor with the specified handler and priority.
+ *
+ * @param[in] handler Function pointer to the actor's handler function.
+ * @param[in] priority Priority of the actor.
+ *
+ * @return Pointer to the created actor instance, or NULL on failure.
+ */
+struct actor *actor_new(actor_handler_t handler, const int priority);
+
+/**
+ * @brief Set the handler and priority of an existing actor.
+ *
+ * This function sets the handler and priority of the specified actor.
+ *
+ * @param[in] actor Pointer to the actor instance.
+ * @param[in] handler Function pointer to the actor's handler function.
+ * @param[in] priority Priority of the actor.
+ *
+ * @return Pointer to the updated actor instance.
+ */
+struct actor *actor_set(struct actor *actor,
+		actor_handler_t handler, const int priority);
+
+/**
+ * @brief Send a message to an actor.
+ *
+ * This function sends a message to the specified actor.
+ *
+ * @param[in] actor Pointer to the actor instance.
+ * @param[in] msg Pointer to the message to be sent.
+ *
+ * @return 0 on success, negative error code on failure.
  */
 int actor_send(struct actor *actor, struct actor_msg *msg);
-int actor_send_defer(struct actor *actor, struct actor_msg *msg,
-		uint32_t millisec_delay);
+
+/**
+ * @brief Send a deferred message to an actor.
+ *
+ * This function sends a message to the specified actor after a delay.
+ *
+ * @param[in] actor Pointer to the actor instance.
+ * @param[in] msg Pointer to the message to be sent.
+ * @param[in] millisec_delay Delay in milliseconds before the message is sent.
+ *
+ * @return 0 on success, negative error code on failure.
+ */
+int actor_send_defer(struct actor *actor,
+		struct actor_msg *msg, const uint32_t millisec_delay);
 
 /**
  * @brief Allocate a memory block of requested size + header
  *
- * @param payload_size size of data to be used by application
+ * @param[in] payload_size size of data to be used by application
  *
  * @return pointer of the memory block on success, NULL otherwise
  */
-struct actor_msg *actor_alloc(size_t payload_size);
+struct actor_msg *actor_alloc(const size_t payload_size);
 int actor_free(struct actor_msg *msg);
+
 size_t actor_cap(void);
 size_t actor_len(void);
 

--- a/modules/actor/src/actor.c
+++ b/modules/actor/src/actor.c
@@ -250,7 +250,7 @@ static int deinitialize_scheduler(struct actor_ctx *ctx)
 	return 0;
 }
 
-struct actor_msg *actor_alloc(size_t payload_size)
+struct actor_msg *actor_alloc(const size_t payload_size)
 {
 	struct list *p = NULL;
 
@@ -344,7 +344,7 @@ int actor_send(struct actor *actor, struct actor_msg *msg)
 }
 
 int actor_send_defer(struct actor *actor, struct actor_msg *msg,
-		uint32_t millisec_delay)
+		const uint32_t millisec_delay)
 {
 	struct actor_timer *timer = actor_timer_new(actor, msg, millisec_delay);
 
@@ -358,7 +358,7 @@ int actor_send_defer(struct actor *actor, struct actor_msg *msg,
 }
 
 struct actor *actor_set(struct actor *actor,
-		actor_handler_t handler, int priority)
+		actor_handler_t handler, const int priority)
 {
 	assert(actor);
 	assert(handler);
@@ -373,7 +373,7 @@ struct actor *actor_set(struct actor *actor,
 	return actor;
 }
 
-int actor_init(void *mem, size_t memsize, size_t stack_size_bytes)
+int actor_init(void *mem, const size_t memsize, const size_t stack_size_bytes)
 {
 	const size_t mask = sizeof(uintptr_t) - 1;
 	const size_t remainder = (size_t)mem & mask;

--- a/ports/esp-idf/wdt.c
+++ b/ports/esp-idf/wdt.c
@@ -15,14 +15,18 @@
 #include "libmcu/list.h"
 #include "libmcu/timext.h"
 
-#if !defined(WDT_INFO)
-#define WDT_INFO(...)
+#if !defined(WDT_STACK_SIZE_BYTES)
+#define WDT_STACK_SIZE_BYTES	1024U
 #endif
 
-#define STACK_SIZE_BYTES	1024
+#define STACK_SIZE_BYTES	WDT_STACK_SIZE_BYTES
 
 #if !defined(MIN)
 #define MIN(a, b)		((a) > (b)? (b) : (a))
+#endif
+
+#if !defined(WDT_INFO)
+#define WDT_INFO(...)
 #endif
 
 struct wdt {


### PR DESCRIPTION
This pull request includes several changes to the `libmcu` library, focusing on improving the documentation, adding new features, and making minor code adjustments. The most important changes include adding detailed documentation for various functions, introducing new functions for application timer management, and making minor code refinements for consistency and clarity.

### Documentation Improvements:
* Added detailed documentation for functions in `apptmr.h`, including descriptions, parameters, and return values for `apptmr_enable`, `apptmr_disable`, `apptmr_start`, `apptmr_restart`, `apptmr_stop`, `apptmr_trigger`, `apptmr_create`, `apptmr_delete`, `apptmr_cap`, and `apptmr_len`.
* Added detailed documentation for functions in `actor.h`, including descriptions, parameters, and return values for `actor_init`, `actor_deinit`, `actor_new`, `actor_set`, `actor_send`, `actor_send_defer`, and `actor_alloc`.

### New Features:
* Introduced new functions `apptmr_cap` and `apptmr_len` in `apptmr.c` to get the capacity and length of application timers respectively.
* Added a counter for created application timers (`count_created`) and updated the `apptmr_create` and `apptmr_delete` functions to manage this counter. [[1]](diffhunk://#diff-5d2bae2b0a15b00d41c3ccee5375b5b820c0cadd8d6a38d9e67d87cce5477a6dR28-R32) [[2]](diffhunk://#diff-5d2bae2b0a15b00d41c3ccee5375b5b820c0cadd8d6a38d9e67d87cce5477a6dR136-R138) [[3]](diffhunk://#diff-5d2bae2b0a15b00d41c3ccee5375b5b820c0cadd8d6a38d9e67d87cce5477a6dR148-R149)

### Code Refinements:
* Changed function parameters to use `const` where applicable in `apptmr.h` and `actor.h` for consistency and clarity. [[1]](diffhunk://#diff-ea4403f362739b13eab849c86e32dd4d5931693ed35046fddcbd815ec6391098L24-R161) [[2]](diffhunk://#diff-305c88601343f1af0718445dcf1131d6750b134e1849c57eca7253e2f68f3cbaL36-R121)
* Updated `start_apptmr`, `restart_apptmr`, and other functions in `apptmr.c` to use `const` for parameters and local variables where appropriate. [[1]](diffhunk://#diff-5d2bae2b0a15b00d41c3ccee5375b5b820c0cadd8d6a38d9e67d87cce5477a6dL56-R64) [[2]](diffhunk://#diff-5d2bae2b0a15b00d41c3ccee5375b5b820c0cadd8d6a38d9e67d87cce5477a6dL70-R78)
* Added missing macro definitions for `APPTMR_INFO` in `apptmr.c` and `WDT_INFO` in `wdt.c` for better debug logging. [[1]](diffhunk://#diff-5d2bae2b0a15b00d41c3ccee5375b5b820c0cadd8d6a38d9e67d87cce5477a6dR15-R18) [[2]](diffhunk://#diff-73dff416cfe64f39bc8a2a9aca2f934e745ff0577114f6ba95082d0640576844L18-R31)

These changes improve the overall quality, maintainability, and functionality of the `libmcu` library.