### PR TITLE
cli: add environment pointer to CLI structure

### DIFF
--- a/modules/cli/include/libmcu/cli.h
+++ b/modules/cli/include/libmcu/cli.h
@@ -37,10 +37,12 @@ struct cli {
 
 	char *buf;
 	size_t bufsize;
+
+	void *env;
 };
 
 void cli_init(struct cli *cli, struct cli_io const *io,
-		void *buf, size_t bufsize);
+		void *buf, size_t bufsize, void *env);
 void cli_register_cmdlist(struct cli *cli, const struct cli_cmd **cmdlist);
 void cli_run(struct cli *cli, void (*sleep)(void));
 cli_cmd_error_t cli_step(struct cli *cli);

--- a/modules/cli/include/libmcu/cli_cmd.h
+++ b/modules/cli/include/libmcu/cli_cmd.h
@@ -28,7 +28,7 @@ typedef enum {
 } cli_cmd_error_t;
 
 typedef cli_cmd_error_t (*cli_cmd_func_t)(int argc, const char *argv[],
-		const void *env);
+		void *env);
 
 struct cli_cmd {
 	char const *name;

--- a/modules/cli/include/libmcu/cli_cmd_macro.h
+++ b/modules/cli/include/libmcu/cli_cmd_macro.h
@@ -145,11 +145,11 @@ extern "C" {
 
 #define DEFINE_CLI_CMD(name, desc)	\
 	static cli_cmd_error_t cli_cmd_##name##_handler(int argc, \
-			const char *argv[], const void *env); \
+			const char *argv[], void *env); \
 	const struct cli_cmd cli_cmd_##name = { #name, \
 			cli_cmd_##name##_handler, desc }; \
 	static cli_cmd_error_t cli_cmd_##name##_handler(int argc, \
-			const char *argv[], const void *env)
+			const char *argv[], void *env)
 
 #define DEFINE_CLI_CMD_LIST(name, ...)	\
 	CLI_ASSERT(CLI_CPP_NARG(__VA_ARGS__) <= CLI_CPP_MAX_CMD); \

--- a/modules/cli/src/cli.c
+++ b/modules/cli/src/cli.c
@@ -321,7 +321,7 @@ static void report_result(struct cli_io const *io, cli_cmd_error_t err,
 }
 
 static cli_cmd_error_t process_command(struct cli const *cli,
-		int argc, char const *argv[], void const *env)
+		int argc, char const *argv[], void *env)
 {
 	if (argc <= 0) {
 		return CLI_CMD_BLANK;
@@ -394,7 +394,7 @@ void cli_register_cmdlist(struct cli *cli, const struct cli_cmd **cmdlist)
 }
 
 void cli_init(struct cli *cli, struct cli_io const *io,
-		void *buf, size_t bufsize)
+		void *buf, size_t bufsize, void *env)
 {
 	CLI_ASSERT(cli != NULL && io != NULL &&
 			buf != NULL && bufsize >= CLI_CMD_MAXLEN);
@@ -409,6 +409,7 @@ void cli_init(struct cli *cli, struct cli_io const *io,
 	cli->history_active = 0;
 	cli->buf = (char *)buf;
 	cli->bufsize = bufsize;
+	cli->env = env;
 
 	io->write(CLI_PROMPT_START_MESSAGE, strlen(CLI_PROMPT_START_MESSAGE));
 	io->write(CLI_PROMPT, strlen(CLI_PROMPT));

--- a/modules/common/src/cobs.c
+++ b/modules/common/src/cobs.c
@@ -37,7 +37,7 @@ size_t cobs_encode(uint8_t *buf, size_t bufsize,
 	buf[group_head_index] = group_len;
 	buf[MIN(o, bufsize - 1)] = 0;
 
-	return o;
+	return o+1;
 }
 
 size_t cobs_decode(uint8_t *buf, size_t bufsize,

--- a/modules/metrics/src/metrics_overrides.c
+++ b/modules/metrics/src/metrics_overrides.c
@@ -31,13 +31,15 @@ LIBMCU_WEAK size_t metrics_encode_header(void *buf, size_t bufsize,
 LIBMCU_WEAK size_t metrics_encode_each(void *buf, size_t bufsize,
 		metric_key_t key, int32_t value)
 {
-	unused(key);
+	const uint32_t kval = (const uint32_t)key;
+	const size_t len = sizeof(kval) + sizeof(value);
 
-	if (bufsize < sizeof(value)) {
+	if (bufsize < len) {
 		return 0;
 	}
 
-	memcpy(buf, &value, sizeof(value));
+	memcpy(buf, &kval, sizeof(kval));
+	memcpy(&buf[sizeof(kval)], &value, sizeof(value));
 
-	return sizeof(value);
+	return len;
 }

--- a/modules/metrics/src/metrics_overrides.c
+++ b/modules/metrics/src/metrics_overrides.c
@@ -39,7 +39,7 @@ LIBMCU_WEAK size_t metrics_encode_each(void *buf, size_t bufsize,
 	}
 
 	memcpy(buf, &kval, sizeof(kval));
-	memcpy(&buf[sizeof(kval)], &value, sizeof(value));
+	memcpy(&((uint8_t *)buf)[sizeof(kval)], &value, sizeof(value));
 
 	return len;
 }

--- a/tests/src/cli/cli_test.cpp
+++ b/tests/src/cli/cli_test.cpp
@@ -66,7 +66,7 @@ TEST_GROUP(cli) {
 		read_index = 0;
 
 		DEFINE_CLI_CMD_LIST(cmd_list, exit, args, error, invalid);
-		cli_init(&cli, &io, cli_buffer, sizeof(cli_buffer));
+		cli_init(&cli, &io, cli_buffer, sizeof(cli_buffer), 0);
 		cli_register_cmdlist(&cli, cmd_list);
 	}
 	void teardown() {

--- a/tests/src/common/cobs_test.cpp
+++ b/tests/src/common/cobs_test.cpp
@@ -21,7 +21,7 @@ TEST(COBS, encode_ShouldReturnEncodedSize2_WhenOneZeroByteGiven) {
 	uint8_t zero = 0;
 	uint8_t expected[] = { 0x01, 0x01, 0x00 };
 	uint8_t actual[sizeof(expected)];
-	LONGS_EQUAL(2, cobs_encode(actual, sizeof(actual), &zero, sizeof(zero)));
+	LONGS_EQUAL(3, cobs_encode(actual, sizeof(actual), &zero, sizeof(zero)));
 	MEMCMP_EQUAL(expected, actual, sizeof(expected));
 }
 
@@ -29,7 +29,7 @@ TEST(COBS, encode_ShouldReturnEncodedSize3_WhenTwoZeroByteGiven) {
 	uint8_t data[] = { 0x00, 0x00 };
 	uint8_t expected[] = { 0x01, 0x01, 0x01, 0x00 };
 	uint8_t actual[sizeof(expected)];
-	LONGS_EQUAL(3, cobs_encode(actual, sizeof(actual), &data, sizeof(data)));
+	LONGS_EQUAL(4, cobs_encode(actual, sizeof(actual), &data, sizeof(data)));
 	MEMCMP_EQUAL(expected, actual, sizeof(expected));
 }
 
@@ -37,7 +37,7 @@ TEST(COBS, encode_ShouldReplaceZeroValueWithOverhead_WhenZeroValueInMiddleGiven)
 	uint8_t data[] = { 0x11, 0x22, 0x00, 0x33 };
 	uint8_t expected[] = { 0x03, 0x11, 0x22, 0x02, 0x33, 0x00 };
 	uint8_t actual[sizeof(expected)];
-	LONGS_EQUAL(5, cobs_encode(actual, sizeof(actual), &data, sizeof(data)));
+	LONGS_EQUAL(6, cobs_encode(actual, sizeof(actual), &data, sizeof(data)));
 	MEMCMP_EQUAL(expected, actual, sizeof(expected));
 }
 
@@ -45,7 +45,7 @@ TEST(COBS, encode_ShouldReplaceZeroValueWithOverhead_WhenZeroValuesTail) {
 	uint8_t data[] = { 0x11, 0x00, 0x00, 0x00 };
 	uint8_t expected[] = { 0x02, 0x11, 0x01, 0x01, 0x01, 0x00 };
 	uint8_t actual[sizeof(expected)];
-	LONGS_EQUAL(5, cobs_encode(actual, sizeof(actual), &data, sizeof(data)));
+	LONGS_EQUAL(6, cobs_encode(actual, sizeof(actual), &data, sizeof(data)));
 	MEMCMP_EQUAL(expected, actual, sizeof(expected));
 }
 
@@ -53,7 +53,7 @@ TEST(COBS, encode_ShouldReturnEncodedSize_WhenNonZeroVauleGiven) {
 	uint8_t data[] = { 0x11, 0x22, 0x33, 0x44 };
 	uint8_t expected[] = { 0x05, 0x11, 0x22, 0x33, 0x44, 0x00 };
 	uint8_t actual[sizeof(expected)];
-	LONGS_EQUAL(5, cobs_encode(actual, sizeof(actual), &data, sizeof(data)));
+	LONGS_EQUAL(6, cobs_encode(actual, sizeof(actual), &data, sizeof(data)));
 	MEMCMP_EQUAL(expected, actual, sizeof(expected));
 }
 
@@ -92,7 +92,7 @@ TEST(COBS, encode_ShouldReturnEncodedSize_When255BytesDataGiven) {
 	expected[255] = 0x02;
 	expected[256] = 0xff;
 	uint8_t actual[sizeof(expected)];
-	LONGS_EQUAL(257, cobs_encode(actual, sizeof(actual), &data, sizeof(data)));
+	LONGS_EQUAL(258, cobs_encode(actual, sizeof(actual), &data, sizeof(data)));
 	MEMCMP_EQUAL(expected, actual, sizeof(expected));
 }
 
@@ -106,7 +106,7 @@ TEST(COBS, encode_ShouldReturnEncodedSize_When255BytesDataWithZeroTailGiven) {
 	expected[255] = 0x01;
 	expected[256] = 0x01;
 	uint8_t actual[sizeof(expected)];
-	LONGS_EQUAL(257, cobs_encode(actual, sizeof(actual), &data, sizeof(data)));
+	LONGS_EQUAL(258, cobs_encode(actual, sizeof(actual), &data, sizeof(data)));
 	MEMCMP_EQUAL(expected, actual, sizeof(expected));
 }
 
@@ -120,7 +120,7 @@ TEST(COBS, encode_ShouldReturnEncodedSize_When255BytesDataWithZeroValueGiven) {
 	expected[254] = 0x02;
 	expected[255] = 0x01;
 	uint8_t actual[sizeof(expected)];
-	LONGS_EQUAL(256, cobs_encode(actual, sizeof(actual), &data, sizeof(data)));
+	LONGS_EQUAL(257, cobs_encode(actual, sizeof(actual), &data, sizeof(data)));
 	MEMCMP_EQUAL(expected, actual, sizeof(expected));
 }
 

--- a/tests/src/metrics/test_metrics.cpp
+++ b/tests/src/metrics/test_metrics.cpp
@@ -134,11 +134,11 @@ TEST(metrics, collect_ShouldReturnSizeOfAllEncodedMetrics_WhenZeroedValueGiven) 
 }
 
 TEST(metrics, collect_ShouldReturnSizeOfAllEncodedMetrics_WhenReportIntervalValueSet) {
-	uint8_t expected_encoded_data[128] = { 0x78, 0x56, 0x34, 0x12, };
+	uint8_t expected_encoded_data[128] = { 0, 0, 0, 0, 0x78, 0x56, 0x34, 0x12, };
 	uint8_t buf[128];
 	metrics_set(ReportInterval, 0x12345678);
 	size_t size = metrics_collect(buf, sizeof(buf));
-	LONGS_EQUAL(4, size);
+	LONGS_EQUAL(8, size);
 	MEMCMP_EQUAL(expected_encoded_data, buf, size);
 }
 


### PR DESCRIPTION
This pull request introduces several significant changes to the `modules/cli` and `modules/common` components, primarily focusing on enhancing the CLI environment handling and improving encoding functions. The most important changes include adding an environment pointer to the CLI structure, modifying function signatures to accommodate this change, and fixing a return value in the COBS encoding function.

Changes to CLI environment handling:

* [`modules/cli/include/libmcu/cli.h`](diffhunk://#diff-e592a9504256378e485c949dab7f7b80b0c230c6b769a5dd6702bedcec3f5d4aR40-R45): Added an `env` pointer to the `struct cli` and updated the `cli_init` function signature to include the `env` parameter.
* [`modules/cli/include/libmcu/cli_cmd.h`](diffhunk://#diff-6fbbba830ccea7d8194b62e15a87436499266aed98a57d5cd501e679e0892355L31-R31): Changed the `cli_cmd_func_t` typedef to use a non-const `env` parameter.
* [`modules/cli/include/libmcu/cli_cmd_macro.h`](diffhunk://#diff-76921a0c7d396d1d3ce8c15b4b3f075c789423ada94b5f6350e15466293d4e21L148-R152): Updated the `DEFINE_CLI_CMD` macro to use a non-const `env` parameter.
* [`modules/cli/src/cli.c`](diffhunk://#diff-f9799fa55c35ec47020b5358b252cf5e2ae03a2f68f86b4b92949f80bae6ff42L324-R324): Updated the `process_command` and `cli_init` functions to handle the new `env` parameter and set the `env` field in the `cli` structure. [[1]](diffhunk://#diff-f9799fa55c35ec47020b5358b252cf5e2ae03a2f68f86b4b92949f80bae6ff42L324-R324) [[2]](diffhunk://#diff-f9799fa55c35ec47020b5358b252cf5e2ae03a2f68f86b4b92949f80bae6ff42L397-R397) [[3]](diffhunk://#diff-f9799fa55c35ec47020b5358b252cf5e2ae03a2f68f86b4b92949f80bae6ff42R412)

Fixes and improvements to encoding functions:

* [`modules/common/src/cobs.c`](diffhunk://#diff-acb6b664bbdcf9ed987835d71be90e89dfaec240fb78f9f4120789ee6bfe9b3eL40-R40): Fixed the return value of the `cobs_encode` function to correctly account for the added zero byte.
* [`modules/metrics/src/metrics_overrides.c`](diffhunk://#diff-1637e568426114bd4563b846e458d359c06b6232d0694f849b22992816202528L34-R44): Improved the `metrics_encode_each` function by encoding both the key and value, and adjusting the buffer size check accordingly.