### PR TITLE
Add apptmr global timeout hook and watchdog periodic callback

### DIFF
--- a/interfaces/apptmr/include/libmcu/apptmr.h
+++ b/interfaces/apptmr/include/libmcu/apptmr.h
@@ -148,6 +148,18 @@ int apptmr_cap(void);
  */
 int apptmr_len(void);
 
+/**
+ * @brief Global timeout hook function for application timer.
+ *
+ * This function is called whenever any registered application timer
+ * reaches its timeout. It serves as a common hook that can be used to
+ * perform actions that need to be executed whenever any timer expires.
+ *
+ * @param self Pointer to the application timer instance that triggered
+ *             the timeout.
+ */
+void apptmr_global_timeout_hook(struct apptmr *self);
+
 #if defined(UNIT_TEST)
 /**
  * @brief Hook function for unit testing application timer creation.

--- a/interfaces/wdt/include/libmcu/wdt.h
+++ b/interfaces/wdt/include/libmcu/wdt.h
@@ -24,6 +24,21 @@ struct wdt;
 typedef void (*wdt_timeout_cb_t)(struct wdt *wdt, void *ctx);
 
 /**
+ * @typedef wdt_periodic_cb_t
+ * @brief Type definition for the periodic callback function.
+ *
+ * This type defines a function pointer for a callback function that is
+ * periodically called by the watchdog timer (WDT) module. The callback
+ * function is intended to be used for user-defined actions that need to be
+ * executed at regular intervals. The smallest timeout period of all registered
+ * watchdog timers is used as the interval for the periodic callback function.
+ *
+ * @param ctx A pointer to user-defined context data that will be passed to
+ *            the callback function when it is called.
+ */
+typedef void (*wdt_periodic_cb_t)(void *ctx);
+
+/**
  * @brief Initialize the watchdog timer module.
  *
  * This function initializes the watchdog timer module. It should be called
@@ -33,7 +48,7 @@ typedef void (*wdt_timeout_cb_t)(struct wdt *wdt, void *ctx);
  *
  * @return 0 on success, negative error code on failure.
  */
-int wdt_init(void);
+int wdt_init(wdt_periodic_cb_t cb, void *cb_ctx);
 
 /**
  * @brief Deinitialize the watchdog timer.

--- a/ports/esp-idf/apptmr.c
+++ b/ports/esp-idf/apptmr.c
@@ -49,6 +49,8 @@ static void callback_wrapper(void *arg)
 {
 	struct apptmr *p = (struct apptmr *)arg;
 
+	apptmr_global_timeout_hook(p);
+
 	if (p && p->callback) {
 		(*p->callback)(p, p->arg);
 	}


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the application timer and watchdog timer modules. The most important changes include the addition of a global timeout hook function for the application timer, the introduction of a periodic callback function for the watchdog timer, and modifications to the watchdog timer initialization and task handling to support the new periodic callback.

### Enhancements to application timer:

* [`interfaces/apptmr/include/libmcu/apptmr.h`](diffhunk://#diff-ea4403f362739b13eab849c86e32dd4d5931693ed35046fddcbd815ec6391098R151-R162): Added a new global timeout hook function `apptmr_global_timeout_hook` that is called whenever any registered application timer reaches its timeout.
* [`ports/esp-idf/apptmr.c`](diffhunk://#diff-5d2bae2b0a15b00d41c3ccee5375b5b820c0cadd8d6a38d9e67d87cce5477a6dR52-R53): Updated the `callback_wrapper` function to call the new `apptmr_global_timeout_hook` function.

### Enhancements to watchdog timer:

* [`interfaces/wdt/include/libmcu/wdt.h`](diffhunk://#diff-032b2570ef43cb2b2670d62de7dd2fb6afae8995372bf444b6e1b2f3ba6abab0R26-R40): Added a new type definition `wdt_periodic_cb_t` for the periodic callback function and updated the `wdt_init` function to accept this new callback and its context as parameters. [[1]](diffhunk://#diff-032b2570ef43cb2b2670d62de7dd2fb6afae8995372bf444b6e1b2f3ba6abab0R26-R40) [[2]](diffhunk://#diff-032b2570ef43cb2b2670d62de7dd2fb6afae8995372bf444b6e1b2f3ba6abab0L36-R51)
* [`ports/esp-idf/wdt.c`](diffhunk://#diff-73dff416cfe64f39bc8a2a9aca2f934e745ff0577114f6ba95082d0640576844L28-R29): Updated the watchdog timer manager structure to include the periodic callback and its context, and modified the `wdt_task` function to call the periodic callback at regular intervals. Additionally, updated the `wdt_init` function to initialize the periodic callback and its context. [[1]](diffhunk://#diff-73dff416cfe64f39bc8a2a9aca2f934e745ff0577114f6ba95082d0640576844L28-R29) [[2]](diffhunk://#diff-73dff416cfe64f39bc8a2a9aca2f934e745ff0577114f6ba95082d0640576844R55-R57) [[3]](diffhunk://#diff-73dff416cfe64f39bc8a2a9aca2f934e745ff0577114f6ba95082d0640576844R88-R106) [[4]](diffhunk://#diff-73dff416cfe64f39bc8a2a9aca2f934e745ff0577114f6ba95082d0640576844L165-R175)