### PR TITLE
test/stubs: fix unmatching wdt_init prototype

### DIFF
--- a/tests/stubs/wdt.cpp
+++ b/tests/stubs/wdt.cpp
@@ -35,7 +35,10 @@ int wdt_feed(struct wdt *self) {
 	return 0;
 }
 
-int wdt_init(void) {
+int wdt_init(wdt_periodic_cb_t cb, void *cb_ctx)
+{
+	(void)cb;
+	(void)cb_ctx;
 	return 0;
 }
 


### PR DESCRIPTION
This pull request includes changes to the `wdt_init` function in the `tests/stubs/wdt.cpp` file to accept a callback and a callback context as parameters. 

The most important change is:

* Modified the `wdt_init` function to accept two new parameters: `wdt_periodic_cb_t cb` and `void *cb_ctx`. These parameters are currently unused within the function body.