### PR TITLE
common/msgq: implement message queue

### DIFF
--- a/modules/common/include/libmcu/msgq.h
+++ b/modules/common/include/libmcu/msgq.h
@@ -1,0 +1,160 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef LIBMCU_MSGQ_H
+#define LIBMCU_MSGQ_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#include <stddef.h>
+
+typedef struct {
+	size_t size;
+} msgq_msg_meta_t;
+
+typedef int (*msgq_lock_fn)(void *);
+typedef int (*msgq_unlock_fn)(void *);
+
+struct msgq;
+
+/**
+ * @brief Creates a message queue with the specified capacity.
+ *
+ * This function initializes a message queue with the given capacity in bytes.
+ *
+ * @note The capacity should be a power of 2 for optimal performance.
+ *
+ * @note The capacity of the message queue is fixed and cannot be changed after
+ *       creation.
+ *
+ * @note A metadata overhead of 4 bytes is added to each message to store the
+ *       size of the message.
+ *
+ * @param[in] capacity_bytes The maximum capacity of the queue in bytes.
+ *
+ * @return A pointer to the created message queue, or NULL if the creation
+ *         fails.
+ */
+struct msgq *msgq_create(const size_t capacity_bytes);
+
+/**
+ * @brief Destroys the specified message queue.
+ *
+ * This function deinitializes the message queue and frees any allocated
+ * resources.
+ *
+ * @param[in] q A pointer to the message queue to be destroyed.
+ */
+void msgq_destroy(struct msgq *q);
+
+/**
+ * @brief Sets synchronization functions for the message queue.
+ *
+ * This function sets custom lock and unlock functions for the message queue to
+ * ensure thread safety. The provided context will be passed to the lock and
+ * unlock functions.
+ *
+ * @param[in] q Pointer to the message queue.
+ * @param[in] lock Function pointer to the lock function.
+ * @param[in] unlock Function pointer to the unlock function.
+ * @param[in] ctx Context to be passed to the lock and unlock functions.
+ *
+ * @return 0 on success, negative value on failure.
+ */
+int msgq_set_sync(struct msgq *q,
+		msgq_lock_fn lock, msgq_unlock_fn unlock, void *ctx);
+
+/**
+ * @brief Pushes a message onto the message queue.
+ *
+ * This function adds a message to the message queue. The message queue uses a
+ * hard-copy approach by default, meaning it copies the message data into the
+ * queue. However, if the user passes a pointer to the data, the queue will
+ * store the pointer, effectively using a soft-copy approach.
+ *
+ * @param[in] q Pointer to the message queue.
+ * @param[in] data Pointer to the message data.
+ * @param[in] datasize Size of the message data.
+ *
+ * @return 0 on success, negative value on failure.
+ */
+int msgq_push(struct msgq *q, const void *data, const size_t datasize);
+
+/**
+ * @brief Pops a message from the message queue.
+ *
+ * This function removes a message from the message queue and copies it into
+ * the provided buffer.
+ *
+ * @note The function uses a hard-copy approach, meaning it copies the message
+ *       data into the buffer. Ensure that the buffer is large enough to hold
+ *       the message data.
+ *
+ * @param[in] q Pointer to the message queue.
+ * @param[out] buf Buffer to copy the message data into.
+ * @param[in] bufsize Size of the buffer.
+ *
+ * @return The length of the message read on success, negative value on failure.
+ */
+int msgq_pop(struct msgq *q, void *buf, size_t bufsize);
+
+/**
+ * @brief Returns the capacity of the message queue.
+ *
+ * This function returns the maximum number of bytes that the message queue can
+ * hold. The capacity is determined during the initialization of the queue.
+ *
+ * @param[in] q Pointer to the message queue.
+ *
+ * @return The capacity of the message queue in bytes.
+ */
+size_t msgq_cap(const struct msgq *q);
+
+/**
+ * @brief Returns the current length of the message queue.
+ *
+ * This function returns the number of bytes currently stored in the message
+ * queue.
+ *
+ * @param[in] q Pointer to the message queue.
+ *
+ * @return The current length of the message queue in bytes.
+ */
+size_t msgq_len(const struct msgq *q);
+
+/**
+ * @brief Get the number of available bytes in the queue.
+ *
+ * This function returns the number of bytes that can be read from
+ * the message queue without blocking.
+ *
+ * @param[in] q Pointer to the message queue structure.
+ *
+ * @return The number of available bytes in the queue.
+ */
+size_t msgq_available(const struct msgq *q);
+
+/**
+ * @brief Returns the size of the next message in the message queue.
+ *
+ * This function returns the size of the next message that can be read from
+ * the message queue without removing it. It allows the caller to determine
+ * the size of the next message before actually reading it. It returns only the
+ * size of the message, not including the metadata overhead.
+ *
+ * @param[in] q Pointer to the message queue.
+ *
+ * @return The size of the next message in bytes, or 0 if the queue is empty.
+ */
+size_t msgq_next_msg_size(const struct msgq *q);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* LIBMCU_MSGQ_H */

--- a/modules/common/src/msgq.c
+++ b/modules/common/src/msgq.c
@@ -1,0 +1,206 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "libmcu/msgq.h"
+
+#include <stdlib.h>
+#include <errno.h>
+
+#include "libmcu/ringbuf.h"
+
+struct msgq {
+	struct ringbuf *ringbuf;
+	size_t capacity;
+
+	msgq_lock_fn lock;
+	msgq_unlock_fn unlock;
+	void *sync_ctx;
+};
+
+static int push_message(struct ringbuf *ringbuf,
+		const void *data, const size_t datasize)
+{
+	const size_t available =
+		ringbuf_capacity(ringbuf) - ringbuf_length(ringbuf);
+	const msgq_msg_meta_t meta = {
+		.size = datasize,
+	};
+	size_t n;
+
+	if (datasize + sizeof(meta) > available) {
+		return -ENOMEM;
+	}
+
+	if ((n = ringbuf_write(ringbuf, &meta, sizeof(meta))) != sizeof(meta)) {
+		ringbuf_write_cancel(ringbuf, n);
+		return -EIO;
+	}
+
+	if ((n = ringbuf_write(ringbuf, data, datasize)) != datasize) {
+		ringbuf_write_cancel(ringbuf, n + sizeof(meta));
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int pop_message(struct ringbuf *ringbuf, void *buf, size_t bufsize)
+{
+	msgq_msg_meta_t meta;
+
+	if (ringbuf_peek(ringbuf, 0, &meta, sizeof(meta)) != sizeof(meta)) {
+		return -ENOENT;
+	}
+
+	if (meta.size > bufsize) {
+		return -ERANGE;
+	}
+
+	if (ringbuf_peek(ringbuf, sizeof(meta), buf, meta.size) != meta.size) {
+		return -EIO;
+	}
+
+	ringbuf_consume(ringbuf, sizeof(meta) + meta.size);
+
+	return (int)meta.size;
+}
+
+int msgq_push(struct msgq *q, const void *data, const size_t datasize)
+{
+	if (q->lock && q->lock(q->sync_ctx) != 0) {
+		return -EAGAIN;
+	}
+
+	int err = push_message(q->ringbuf, data, datasize);
+
+	if (q->unlock) {
+		err |= q->unlock(q->sync_ctx);
+	}
+
+	return err;
+}
+
+int msgq_pop(struct msgq *q, void *buf, size_t bufsize)
+{
+	if (q->lock && q->lock(q->sync_ctx) != 0) {
+		return -EAGAIN;
+	}
+
+	int bytes_read = pop_message(q->ringbuf, buf, bufsize);
+
+	if (q->unlock) {
+		q->unlock(q->sync_ctx);
+	}
+
+	return bytes_read;
+}
+
+size_t msgq_next_msg_size(const struct msgq *q)
+{
+	msgq_msg_meta_t meta;
+
+	if (q->lock && q->lock(q->sync_ctx) != 0) {
+		return 0;
+	}
+
+	if (ringbuf_peek(q->ringbuf, 0, &meta, sizeof(meta)) != sizeof(meta)) {
+		return 0;
+	}
+
+	if (q->unlock) {
+		q->unlock(q->sync_ctx);
+	}
+
+	return meta.size;
+}
+
+size_t msgq_available(const struct msgq *q)
+{
+	if (q->lock && q->lock(q->sync_ctx) != 0) {
+		return 0;
+	}
+
+	const size_t available = ringbuf_capacity(q->ringbuf)
+		- ringbuf_length(q->ringbuf);
+
+	if (q->unlock) {
+		q->unlock(q->sync_ctx);
+	}
+
+	return available < sizeof(msgq_msg_meta_t) ?
+		0 : available - sizeof(msgq_msg_meta_t);
+}
+
+size_t msgq_cap(const struct msgq *q)
+{
+	if (q->lock && q->lock(q->sync_ctx) != 0) {
+		return 0;
+	}
+
+	size_t cap = ringbuf_capacity(q->ringbuf);
+
+	if (q->unlock) {
+		q->unlock(q->sync_ctx);
+	}
+
+	return cap;
+}
+
+size_t msgq_len(const struct msgq *q)
+{
+	if (q->lock && q->lock(q->sync_ctx) != 0) {
+		return 0;
+	}
+
+	size_t len = ringbuf_length(q->ringbuf);
+
+	if (q->unlock) {
+		q->unlock(q->sync_ctx);
+	}
+
+	return len;
+}
+
+int msgq_set_sync(struct msgq *q,
+		msgq_lock_fn lock, msgq_unlock_fn unlock, void *ctx)
+{
+	q->lock = lock;
+	q->unlock = unlock;
+	q->sync_ctx = ctx;
+
+	return 0;
+}
+
+struct msgq *msgq_create(const size_t capacity_bytes)
+{
+	struct msgq *q;
+
+	if (capacity_bytes == 0) {
+		return NULL;
+	}
+
+	if ((q = (struct msgq *)malloc(sizeof(struct msgq)))) {
+		if ((q->ringbuf = ringbuf_create(capacity_bytes)) == NULL) {
+			free(q);
+			return NULL;
+		}
+
+		q->capacity = capacity_bytes;
+		q->lock = NULL;
+		q->unlock = NULL;
+		q->sync_ctx = NULL;
+	}
+
+	return q;
+}
+
+void msgq_destroy(struct msgq *q)
+{
+	if (q) {
+		ringbuf_destroy(q->ringbuf);
+		free(q);
+	}
+}

--- a/tests/runners/common/msgq.mk
+++ b/tests/runners/common/msgq.mk
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: MIT
+
+COMPONENT_NAME = MessageQueue
+
+SRC_FILES = \
+	../modules/common/src/msgq.c \
+	../modules/common/src/ringbuf.c \
+	stubs/bitops.c \
+
+TEST_SRC_FILES = \
+	src/common/msgq_test.cpp \
+	src/test_all.cpp \
+
+INCLUDE_DIRS = \
+	../modules/common/include \
+	$(CPPUTEST_HOME)/include \
+
+MOCKS_SRC_DIRS =
+CPPUTEST_CPPFLAGS =
+
+include runners/MakefileRunner

--- a/tests/src/common/msgq_test.cpp
+++ b/tests/src/common/msgq_test.cpp
@@ -1,0 +1,249 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "CppUTest/TestHarness.h"
+#include "CppUTest/TestHarness_c.h"
+#include "CppUTestExt/MockSupport.h"
+#include "libmcu/msgq.h"
+
+static int f_lock(void *ctx) {
+	return mock().actualCall(__func__)
+		.withParameter("ctx", ctx)
+		.returnIntValueOrDefault(0);
+}
+
+static int f_unlock(void *ctx) {
+	return mock().actualCall(__func__)
+		.withParameter("ctx", ctx)
+		.returnIntValueOrDefault(0);
+}
+
+TEST_GROUP(MessageQueue) {
+	struct msgq *msgq;
+	void *sync_ctx;
+
+	void setup(void) {
+		msgq = msgq_create(128);
+	}
+	void teardown(void) {
+		msgq_destroy(msgq);
+
+		mock().checkExpectations();
+		mock().clear();
+	}
+};
+
+TEST(MessageQueue, create_ShouldReturnNull_WhenCapacityIsZero) {
+	struct msgq *q = msgq_create(0);
+	LONGS_EQUAL(NULL, q);
+}
+
+TEST(MessageQueue, create_ShouldReturnValidPointer_WhenCapacityIsGreaterThanZero) {
+	CHECK_TRUE(msgq);
+}
+
+TEST(MessageQueue, set_sync_ShouldReturnZero_WhenLockAndUnlockFunctionsAreValid) {
+	LONGS_EQUAL(0, msgq_set_sync(msgq, f_lock, f_unlock, sync_ctx));
+}
+
+TEST(MessageQueue, set_sync_ShouldReturnZero_WhenNullFuncationsGiven) {
+	LONGS_EQUAL(0, msgq_set_sync(msgq, NULL, NULL, NULL));
+}
+
+TEST(MessageQueue, cap_ShouldReturnQueueCapacity) {
+	LONGS_EQUAL(128, msgq_cap(msgq));
+}
+
+TEST(MessageQueue, cap_ShouldReturnPowerOfTwo_WhenCapacityIsNotPowerOfTwo) {
+	struct msgq *q = msgq_create(150);
+	LONGS_EQUAL(128, msgq_cap(q));
+	msgq_destroy(q);
+}
+
+TEST(MessageQueue, len_ShouldReturnZero_WhenQueueIsEmpty) {
+	LONGS_EQUAL(0, msgq_len(msgq));
+}
+
+TEST(MessageQueue, len_ShouldReturnNonZero_WhenQueueIsNotEmpty) {
+	const char *msg = "hello";
+	msgq_push(msgq, msg, strlen(msg));
+	CHECK_TRUE(msgq_len(msgq));
+}
+
+TEST(MessageQueue, len_ShouldReturnSumOfAllMessagesAndMetadata_WhenQueueIsNotEmpty) {
+	const char *msg1 = "hello";
+	const char *msg2 = "world";
+	msgq_push(msgq, msg1, strlen(msg1));
+	msgq_push(msgq, msg2, strlen(msg2));
+	LONGS_EQUAL(strlen(msg1) + strlen(msg2) + 2 * sizeof(msgq_msg_meta_t), msgq_len(msgq));
+}
+
+TEST(MessageQueue, push_ShouldCallSyncFunctions_WhenLockAndUnlockAreSet) {
+	mock().expectOneCall("f_lock")
+		.withParameter("ctx", sync_ctx);
+	mock().expectOneCall("f_unlock")
+		.withParameter("ctx", sync_ctx);
+	msgq_set_sync(msgq, f_lock, f_unlock, sync_ctx);
+	msgq_push(msgq, "hello", 5);
+}
+
+TEST(MessageQueue, push_ShouldReturnEAGAIN_WhenLockReturnsNonZero) {
+	mock().expectOneCall("f_lock")
+		.withParameter("ctx", sync_ctx)
+		.andReturnValue(-1);
+	msgq_set_sync(msgq, f_lock, f_unlock, sync_ctx);
+	LONGS_EQUAL(-EAGAIN, msgq_push(msgq, "hello", 5));
+}
+
+TEST(MessageQueue, push_ShouldReturnUnlockError_WhenUnlockReturnsNonZero) {
+	mock().expectOneCall("f_lock")
+		.withParameter("ctx", sync_ctx)
+		.andReturnValue(0);
+	mock().expectOneCall("f_unlock")
+		.withParameter("ctx", sync_ctx)
+		.andReturnValue(-2);
+	msgq_set_sync(msgq, f_lock, f_unlock, sync_ctx);
+	LONGS_EQUAL(-2, msgq_push(msgq, "hello", 5));
+}
+
+TEST(MessageQueue, push_ShouldReturnZero_WhenSuccess) {
+	LONGS_EQUAL(0, msgq_push(msgq, "hello", 5));
+}
+
+TEST(MessageQueue, push_ShouldReturnNOMEM_WhenQueueIsFull) {
+	uint8_t data[128-sizeof(msgq_msg_meta_t)];
+	LONGS_EQUAL(0, msgq_push(msgq, data, sizeof(data)));
+	LONGS_EQUAL(-ENOMEM, msgq_push(msgq, data, 1));
+}
+
+TEST(MessageQueue, pop_ShouldReturnENOENT_WhenQueueIsEmpty) {
+	uint8_t buf[16];
+	LONGS_EQUAL(-ENOENT, msgq_pop(msgq, buf, sizeof(buf)));
+}
+
+TEST(MessageQueue, pop_ShouldReturnERANGE_WhenBufSizeIsSmallerThanMessageSize) {
+	const char *msg = "hello";
+	msgq_push(msgq, msg, strlen(msg));
+	uint8_t buf[4];
+	LONGS_EQUAL(-ERANGE, msgq_pop(msgq, buf, sizeof(buf)));
+}
+
+TEST(MessageQueue, pop_ShouldReturnZero_WhenSuccess) {
+	const char *msg = "hello";
+	msgq_push(msgq, msg, strlen(msg));
+	uint8_t buf[16];
+	LONGS_EQUAL((int)strlen(msg), msgq_pop(msgq, buf, sizeof(buf)));
+}
+
+TEST(MessageQueue, pop_ShouldResultInSameMessage_WhenSuccess) {
+	const char *msg = "hello";
+	msgq_push(msgq, msg, strlen(msg));
+	uint8_t buf[16];
+	LONGS_EQUAL((int)strlen(msg), msgq_pop(msgq, buf, sizeof(buf)));
+	LONGS_EQUAL(0, strncmp(msg, (const char *)buf, strlen(msg)));
+}
+
+TEST(MessageQueue, pop_ShouldReturnZero_WhenSuccess_WithMultipleMessages) {
+	const char *msg1 = "hello";
+	const char *msg2 = "world";
+	msgq_push(msgq, msg1, strlen(msg1));
+	msgq_push(msgq, msg2, strlen(msg2));
+	uint8_t buf[16];
+	LONGS_EQUAL((int)strlen(msg1), msgq_pop(msgq, buf, sizeof(buf)));
+	LONGS_EQUAL(0, strncmp(msg1, (const char *)buf, strlen(msg1)));
+}
+
+TEST(MessageQueue, pop_ShouldReturnZero_WhenSuccess_WithMultipleMessages2) {
+	const char *msg1 = "hello";
+	const char *msg2 = "world";
+	msgq_push(msgq, msg1, strlen(msg1));
+	msgq_push(msgq, msg2, strlen(msg2));
+	uint8_t buf[16];
+	LONGS_EQUAL((int)strlen(msg1), msgq_pop(msgq, buf, sizeof(buf)));
+	LONGS_EQUAL(0, strncmp(msg1, (const char *)buf, strlen(msg1)));
+	LONGS_EQUAL((int)strlen(msg2), msgq_pop(msgq, buf, sizeof(buf)));
+	LONGS_EQUAL(0, strncmp(msg2, (const char *)buf, strlen(msg2)));
+}
+
+TEST(MessageQueue, pop_ShouldCallSyncFunctions_WhenLockAndUnlockAreSet) {
+	mock().expectNCalls(2, "f_lock")
+		.withParameter("ctx", sync_ctx);
+	mock().expectNCalls(2, "f_unlock")
+		.withParameter("ctx", sync_ctx);
+	msgq_set_sync(msgq, f_lock, f_unlock, sync_ctx);
+	msgq_push(msgq, "hello", 5);
+	uint8_t buf[16];
+	msgq_pop(msgq, buf, sizeof(buf));
+}
+
+TEST(MessageQueue, next_msg_size_ShouldReturnZero_WhenQueueIsEmpty) {
+	LONGS_EQUAL(0, msgq_next_msg_size(msgq));
+}
+
+TEST(MessageQueue, next_msg_size_ShouldReturnMessageSize_WhenQueueIsNotEmpty) {
+	const char *msg = "hello";
+	msgq_push(msgq, msg, strlen(msg));
+	LONGS_EQUAL(strlen(msg), msgq_next_msg_size(msgq));
+}
+
+TEST(MessageQueue, next_msg_size_ShouldReturnZero_WhenQueueIsNotEmpty) {
+	const char *msg1 = "hello";
+	const char *msg2 = "world";
+	msgq_push(msgq, msg1, strlen(msg1));
+	msgq_push(msgq, msg2, strlen(msg2));
+	LONGS_EQUAL(strlen(msg1), msgq_next_msg_size(msgq));
+}
+
+TEST(MessageQueue, next_msg_ShouldCallSyncFunctions_WhenLockAndUnlockAreSet) {
+	mock().expectNCalls(2, "f_lock")
+		.withParameter("ctx", sync_ctx);
+	mock().expectNCalls(2, "f_unlock")
+		.withParameter("ctx", sync_ctx);
+	msgq_set_sync(msgq, f_lock, f_unlock, sync_ctx);
+	msgq_push(msgq, "hello", 5);
+	msgq_next_msg_size(msgq);
+}
+
+TEST(MessageQueue, available_ShouldReturnZero_WhenQueueIsFull) {
+	uint8_t data[128-sizeof(msgq_msg_meta_t)];
+	LONGS_EQUAL(sizeof(data), msgq_available(msgq));
+	msgq_push(msgq, data, sizeof(data));
+	LONGS_EQUAL(0, msgq_available(msgq));
+}
+
+TEST(MessageQueue, available_ShouldReturnAvailableBytes_WhenQueueIsNotFull) {
+	const size_t expected = 128-sizeof(msgq_msg_meta_t)*2-5;
+	LONGS_EQUAL(128-sizeof(msgq_msg_meta_t), msgq_available(msgq));
+	msgq_push(msgq, "hello", 5);
+	LONGS_EQUAL(expected, msgq_available(msgq));
+}
+
+TEST(MessageQueue, available_ShouldCallSyncFunctions_WhenLockAndUnlockAreSet) {
+	mock().expectOneCall("f_lock")
+		.withParameter("ctx", sync_ctx);
+	mock().expectOneCall("f_unlock")
+		.withParameter("ctx", sync_ctx);
+	msgq_set_sync(msgq, f_lock, f_unlock, sync_ctx);
+	msgq_available(msgq);
+}
+
+TEST(MessageQueue, cap_ShouldCallSyncFunctions_WhenLockAndUnlockAreSet) {
+	mock().expectOneCall("f_lock")
+		.withParameter("ctx", sync_ctx);
+	mock().expectOneCall("f_unlock")
+		.withParameter("ctx", sync_ctx);
+	msgq_set_sync(msgq, f_lock, f_unlock, sync_ctx);
+	msgq_cap(msgq);
+}
+
+TEST(MessageQueue, len_ShouldCallSyncFunctions_WhenLockAndUnlockAreSet) {
+	mock().expectOneCall("f_lock")
+		.withParameter("ctx", sync_ctx);
+	mock().expectOneCall("f_unlock")
+		.withParameter("ctx", sync_ctx);
+	msgq_set_sync(msgq, f_lock, f_unlock, sync_ctx);
+	msgq_len(msgq);
+}

--- a/tests/src/common/ringbuf_test.cpp
+++ b/tests/src/common/ringbuf_test.cpp
@@ -296,3 +296,15 @@ TEST(RingBuffer, peek_pointer_ShouldSetOnlyContiguousSize_WhenWraparound) {
 	POINTERS_EQUAL(&ringbuf_space[SPACE_SIZE-11], ptr);
 	LONGS_EQUAL(11, contiguous);
 }
+
+TEST(RingBuffer, read_ShouldReturnZero_WhenRingBufferIsEmpty) {
+	prepare_test();
+	uint8_t buf[5];
+	LONGS_EQUAL(0, ringbuf_read(&ringbuf_obj, 0, buf, sizeof(buf)));
+}
+
+TEST(RingBuffer, peek_ShouldReturnZero_WhenRingBufferIsEmpty) {
+	prepare_test();
+	uint8_t buf[5];
+	LONGS_EQUAL(0, ringbuf_peek(&ringbuf_obj, 0, buf, sizeof(buf)));
+}


### PR DESCRIPTION
This pull request introduces a new message queue implementation and adds atomic operations to the ring buffer. The changes include the addition of a new message queue library, updates to the ring buffer to support atomic operations, and comprehensive tests for the new message queue functionality.

New message queue implementation:

* [`modules/common/include/libmcu/msgq.h`](diffhunk://#diff-70c891df4d5b6b9c12f7a575e57d4bfa443391122470abd3872d5768eece17e6R1-R147): Added a new header file defining the message queue interface, including functions for creating, destroying, and managing message queues.
* [`modules/common/src/msgq.c`](diffhunk://#diff-6165b812a05e3c9752e7a1f8225fce31e2d59b48cb54f5d1e4ea01fdb21dcb6aR1-R178): Implemented the message queue functionality, including push and pop operations, synchronization, and capacity management.

Atomic operations in ring buffer:

* [`modules/common/src/ringbuf.c`](diffhunk://#diff-2c724b5849dee4299cf6d31c22677d6033b58bddab276ca3240867d78f0736acR11-R13): Added atomic thread fences to ensure memory order consistency during read, write, and cancel operations. [[1]](diffhunk://#diff-2c724b5849dee4299cf6d31c22677d6033b58bddab276ca3240867d78f0736acR11-R13) [[2]](diffhunk://#diff-2c724b5849dee4299cf6d31c22677d6033b58bddab276ca3240867d78f0736acR93-R95) [[3]](diffhunk://#diff-2c724b5849dee4299cf6d31c22677d6033b58bddab276ca3240867d78f0736acR113-R115) [[4]](diffhunk://#diff-2c724b5849dee4299cf6d31c22677d6033b58bddab276ca3240867d78f0736acR127-R129)

Testing:

* [`tests/src/common/msgq_test.cpp`](diffhunk://#diff-1ed3181d4a21e2263d3357a9e5aa2da73ed7924612024f86562788f407789823R1-R187): Added comprehensive tests for the message queue, covering creation, synchronization, capacity, and message operations.
* [`tests/src/common/ringbuf_test.cpp`](diffhunk://#diff-f52cd869ab662068ea1473932643422779d83cf52c70e7324ef6787b9f31559aR299-R310): Added tests to verify the behavior of the ring buffer when it is empty.