### PR TITLE
common/msgq: add function to calculate total queue size

### DIFF
--- a/modules/common/include/libmcu/msgq.h
+++ b/modules/common/include/libmcu/msgq.h
@@ -153,6 +153,19 @@ size_t msgq_available(const struct msgq *q);
  */
 size_t msgq_next_msg_size(const struct msgq *q);
 
+/**
+ * @brief Calculate the total size of the message queue.
+ *
+ * This function calculates the total size required for a message queue
+ * based on the number of messages and the maximum size of each message.
+ *
+ * @param[in] n The number of messages in the queue.
+ * @param[in] max_msg_size The maximum size of each message.
+ *
+ * @return The total size required for the message queue.
+ */
+size_t msgq_calc_size(const size_t n, const size_t max_msg_size);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/modules/common/src/msgq.c
+++ b/modules/common/src/msgq.c
@@ -174,6 +174,11 @@ int msgq_set_sync(struct msgq *q,
 	return 0;
 }
 
+size_t msgq_calc_size(const size_t n, const size_t max_msg_size)
+{
+	return (sizeof(msgq_msg_meta_t) + max_msg_size) * n;
+}
+
 struct msgq *msgq_create(const size_t capacity_bytes)
 {
 	struct msgq *q;

--- a/tests/src/common/msgq_test.cpp
+++ b/tests/src/common/msgq_test.cpp
@@ -247,3 +247,9 @@ TEST(MessageQueue, len_ShouldCallSyncFunctions_WhenLockAndUnlockAreSet) {
 	msgq_set_sync(msgq, f_lock, f_unlock, sync_ctx);
 	msgq_len(msgq);
 }
+
+TEST(MessageQueue, calc_size_ShouldReturnTotalBytesRequiredForNumberOfMessages) {
+	struct msg { uint8_t data[4]; };
+	LONGS_EQUAL((sizeof(msg)+sizeof(msgq_msg_meta_t))*10,
+			msgq_calc_size(10, sizeof(msg)));
+}


### PR DESCRIPTION
This pull request introduces a new function to calculate the total size required for a message queue based on the number of messages and the maximum size of each message. The changes are made in both the header and source files of the message queue module.

New function addition:

* [`modules/common/include/libmcu/msgq.h`](diffhunk://#diff-70c891df4d5b6b9c12f7a575e57d4bfa443391122470abd3872d5768eece17e6R156-R168): Added the declaration of the `msgq_calc_size` function, which calculates the total size required for a message queue.

* [`modules/common/src/msgq.c`](diffhunk://#diff-6165b812a05e3c9752e7a1f8225fce31e2d59b48cb54f5d1e4ea01fdb21dcb6aR177-R181): Implemented the `msgq_calc_size` function, which returns the calculated size based on the number of messages and their maximum size.