### PR TITLE
common/msgq: round up size to nearest power of two

### DIFF
--- a/modules/common/include/libmcu/bitops.h
+++ b/modules/common/include/libmcu/bitops.h
@@ -14,7 +14,7 @@ extern "C" {
 #include <stdbool.h>
 #include <limits.h>
 
-static inline bool is_power2(unsigned int x)
+static inline bool is_power2(const unsigned long x)
 {
 	return (x != 0) && ((x & (x - 1)) == 0);
 }

--- a/modules/common/src/msgq.c
+++ b/modules/common/src/msgq.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 
 #include "libmcu/ringbuf.h"
+#include "libmcu/bitops.h"
 
 struct msgq {
 	struct ringbuf *ringbuf;
@@ -176,7 +177,10 @@ int msgq_set_sync(struct msgq *q,
 
 size_t msgq_calc_size(const size_t n, const size_t max_msg_size)
 {
-	return (sizeof(msgq_msg_meta_t) + max_msg_size) * n;
+	const size_t requested = (sizeof(msgq_msg_meta_t) + max_msg_size) * n;
+	const int bit = flsl((long)requested);
+	const int bit_corrected = is_power2(requested)? bit-1 : bit;
+	return 1UL << bit_corrected;
 }
 
 struct msgq *msgq_create(const size_t capacity_bytes)

--- a/tests/runners/common/msgq.mk
+++ b/tests/runners/common/msgq.mk
@@ -5,6 +5,7 @@ COMPONENT_NAME = MessageQueue
 SRC_FILES = \
 	../modules/common/src/msgq.c \
 	../modules/common/src/ringbuf.c \
+	../modules/common/src/bitops.c \
 	stubs/bitops.c \
 
 TEST_SRC_FILES = \

--- a/tests/src/common/msgq_test.cpp
+++ b/tests/src/common/msgq_test.cpp
@@ -250,6 +250,12 @@ TEST(MessageQueue, len_ShouldCallSyncFunctions_WhenLockAndUnlockAreSet) {
 
 TEST(MessageQueue, calc_size_ShouldReturnTotalBytesRequiredForNumberOfMessages) {
 	struct msg { uint8_t data[4]; };
-	LONGS_EQUAL((sizeof(msg)+sizeof(msgq_msg_meta_t))*10,
-			msgq_calc_size(10, sizeof(msg)));
+	LONGS_EQUAL(120, (sizeof(msg)+sizeof(msgq_msg_meta_t))*10);
+	LONGS_EQUAL(120+8, msgq_calc_size(10, sizeof(msg)));
+}
+
+TEST(MessageQueue, calc_size_ShouldReturnRoundUpToPowerOfTwo) {
+	LONGS_EQUAL(16, msgq_calc_size(1, 1));
+	LONGS_EQUAL(16, msgq_calc_size(1, 8));
+	LONGS_EQUAL(32, msgq_calc_size(1, 9));
 }


### PR DESCRIPTION
This pull request includes several changes to the message queue (`msgq`) implementation, primarily focusing on improving the calculation of message queue sizes and ensuring proper inclusion of dependencies.

Improvements to message queue size calculation:

* [`modules/common/include/libmcu/bitops.h`](diffhunk://#diff-45a08a1645f21da9c2637afbe246a7d24e899dd2ad28eff3abaf76b797587d8fL17-R17): Changed the `is_power2` function to accept `const unsigned long` instead of `unsigned int` for better compatibility with larger values.
* [`modules/common/src/msgq.c`](diffhunk://#diff-6165b812a05e3c9752e7a1f8225fce31e2d59b48cb54f5d1e4ea01fdb21dcb6aL179-R183): Updated the `msgq_calc_size` function to round up the size to the nearest power of two, ensuring more efficient memory usage.

Dependency management:

* [`modules/common/src/msgq.c`](diffhunk://#diff-6165b812a05e3c9752e7a1f8225fce31e2d59b48cb54f5d1e4ea01fdb21dcb6aR13): Added an include directive for `libmcu/bitops.h` to ensure the `is_power2` function is available.
* [`tests/runners/common/msgq.mk`](diffhunk://#diff-c0c04a2798dcb9d8d11e6feeba6b37da87422ae1ebd1d6bcefe1785d1ab24e67R8): Included `bitops.c` in the source files to ensure all necessary dependencies are compiled.

Testing enhancements:

* [`tests/src/common/msgq_test.cpp`](diffhunk://#diff-1ed3181d4a21e2263d3357a9e5aa2da73ed7924612024f86562788f407789823L253-R260): Added new tests to verify the updated behavior of `msgq_calc_size`, ensuring it correctly rounds up to the nearest power of two.