### PR TITLE
fsm: add state change callback support

### DIFF
--- a/modules/fsm/include/libmcu/fsm.h
+++ b/modules/fsm/include/libmcu/fsm.h
@@ -28,6 +28,10 @@ typedef void (*fsm_handler_t)(fsm_state_t state, fsm_state_t next_state,
 typedef bool (*fsm_event_t)(fsm_state_t state, fsm_state_t next_state,
 		void *ctx);
 
+struct fsm;
+typedef void (*fsm_state_change_cb_t)(struct fsm *fsm,
+		fsm_state_t new_state, fsm_state_t prev_state, void *ctx);
+
 struct fsm_action {
 	fsm_handler_t run;
 };
@@ -48,6 +52,9 @@ struct fsm {
 	const struct fsm_item *item;
 	size_t item_len;
 	void *ctx;
+
+	fsm_state_change_cb_t cb;
+	void *cb_ctx;
 };
 
 /**
@@ -60,6 +67,21 @@ struct fsm {
  */
 void fsm_init(struct fsm *fsm,
 		const struct fsm_item *items, size_t item_len, void *ctx);
+
+/**
+ * @brief Set the callback for state changes in the finite state machine.
+ *
+ * This function sets a callback function that will be called whenever the
+ * state of the finite state machine (FSM) changes. The callback function
+ * will be provided with the FSM instance, the new state, and the user-defined
+ * context.
+ *
+ * @param[in] fsm Pointer to the FSM structure.
+ * @param[in] cb The callback function to be called on state changes.
+ * @param[in] cb_ctx User-defined context to be passed to the callback function.
+ */
+void fsm_set_state_change_cb(struct fsm *fsm,
+		fsm_state_change_cb_t cb, void *cb_ctx);
 
 /**
  * @brief Perform a single step in the finite state machine.

--- a/modules/fsm/src/fsm.c
+++ b/modules/fsm/src/fsm.c
@@ -50,12 +50,23 @@ fsm_state_t fsm_step(struct fsm *fsm)
 		}
 	}
 
+	if (fsm->cb && current_state != fsm->state.present) {
+		(*fsm->cb)(fsm, fsm->state.present, current_state, fsm->cb_ctx);
+	}
+
 	return fsm->state.present;
 }
 
 fsm_state_t fsm_state(const struct fsm *fsm)
 {
 	return fsm->state.present;
+}
+
+void fsm_set_state_change_cb(struct fsm *fsm,
+		fsm_state_change_cb_t cb, void *cb_ctx)
+{
+	fsm->cb = cb;
+	fsm->cb_ctx = cb_ctx;
 }
 
 void fsm_reset(struct fsm *fsm)

--- a/tests/src/fsm/fsm_test.cpp
+++ b/tests/src/fsm/fsm_test.cpp
@@ -11,75 +11,58 @@
 #include "libmcu/fsm.h"
 
 enum {
-	READY,
-	OCCUPIED,
-	CHARGING,
-	UNAVAILABLE,
+	A,
+	B,
+	C,
 };
 
-static bool is_plugged_in(fsm_state_t state, fsm_state_t next_state,
-		void *ctx) {
+static bool is_state_a(fsm_state_t state, fsm_state_t next_state, void *ctx) {
 	return mock().actualCall(__func__).returnBoolValueOrDefault(false);
 }
 
-static bool is_plugged_out(fsm_state_t state, fsm_state_t next_state,
-		void *ctx) {
+static bool is_state_b(fsm_state_t state, fsm_state_t next_state, void *ctx) {
 	return mock().actualCall(__func__).returnBoolValueOrDefault(false);
 }
 
-static bool has_rfid_tagged(fsm_state_t state, fsm_state_t next_state,
-		void *ctx) {
+static bool is_state_c(fsm_state_t state, fsm_state_t next_state, void *ctx) {
 	return mock().actualCall(__func__).returnBoolValueOrDefault(false);
 }
 
-static bool has_remotely_started(fsm_state_t state, fsm_state_t next_state,
-		void *ctx) {
-	return mock().actualCall(__func__).returnBoolValueOrDefault(false);
-}
-
-static bool has_remotely_stopped(fsm_state_t state, fsm_state_t next_state,
-		void *ctx) {
-	return mock().actualCall(__func__).returnBoolValueOrDefault(false);
-}
-
-static bool is_timed_out(fsm_state_t state, fsm_state_t next_state, void *ctx) {
-	return mock().actualCall(__func__).returnBoolValueOrDefault(false);
-}
-
-static bool is_suspended_by_ev(fsm_state_t state, fsm_state_t next_state,
-		void *ctx) {
-	return mock().actualCall(__func__).returnBoolValueOrDefault(false);
-}
-
-static bool is_resumed_from_suspended(fsm_state_t state, fsm_state_t next_state,
-		void *ctx) {
-	return mock().actualCall(__func__).returnBoolValueOrDefault(false);
-}
-
-static bool has_hardware_error(fsm_state_t state, fsm_state_t next_state,
-		void *ctx) {
-	return mock().actualCall(__func__).returnBoolValueOrDefault(false);
-}
-
-static bool is_hardware_recovered(fsm_state_t state, fsm_state_t next_state,
-		void *ctx) {
-	return mock().actualCall(__func__).returnBoolValueOrDefault(false);
-}
-
-static void turn_relay_on(fsm_state_t state, fsm_state_t next_state,
-		void *ctx) {
+static void do_state_a(fsm_state_t state, fsm_state_t next_state, void *ctx) {
 	mock().actualCall(__func__);
 }
 
-static void turn_relay_off(fsm_state_t state, fsm_state_t next_state,
-		void *ctx) {
+static void do_state_b(fsm_state_t state, fsm_state_t next_state, void *ctx) {
 	mock().actualCall(__func__);
 }
+
+static void do_state_c(fsm_state_t state, fsm_state_t next_state, void *ctx) {
+	mock().actualCall(__func__);
+}
+
+static void on_state_change(struct fsm *fsm, fsm_state_t new_state,
+		fsm_state_t prev_state, void *ctx) {
+	mock().actualCall(__func__).withParameter("new_state", new_state)
+		.withParameter("prev_state", prev_state);
+}
+
+static const struct fsm_item transitions[] = {
+	FSM_ITEM(A, NULL,       do_state_a, A),
+	FSM_ITEM(A, is_state_b, do_state_b, B),
+	FSM_ITEM(A, is_state_c, do_state_c, C),
+	FSM_ITEM(B, is_state_a, do_state_a, A),
+	FSM_ITEM(B, is_state_c, do_state_c, C),
+	FSM_ITEM(C, is_state_a, do_state_a, A),
+	FSM_ITEM(C, is_state_b, do_state_b, B),
+	FSM_ITEM(C, is_state_c, NULL,       C),
+};
 
 TEST_GROUP(FSM) {
 	struct fsm fsm;
 
 	void setup(void) {
+		fsm_init(&fsm, transitions,
+				sizeof(transitions) / sizeof(*transitions), 0);
 	}
 	void teardown(void) {
 		mock().checkExpectations();
@@ -87,41 +70,71 @@ TEST_GROUP(FSM) {
 	}
 };
 
-TEST(FSM, test) {
-	struct fsm_item items[] = {
-		FSM_ITEM(READY, is_plugged_in, NULL, OCCUPIED),
-		FSM_ITEM(READY, has_rfid_tagged, NULL, OCCUPIED),
-		FSM_ITEM(READY, has_remotely_started, NULL, OCCUPIED),
-		FSM_ITEM(OCCUPIED, is_plugged_in, turn_relay_on, CHARGING),
-		FSM_ITEM(OCCUPIED, has_rfid_tagged, turn_relay_on, CHARGING),
-		FSM_ITEM(OCCUPIED, has_remotely_started, turn_relay_on, CHARGING),
-		FSM_ITEM(OCCUPIED, is_timed_out, NULL, READY),
-		FSM_ITEM(OCCUPIED, is_plugged_out, NULL, READY),
-		FSM_ITEM(CHARGING, is_plugged_out, turn_relay_off, READY),
-		FSM_ITEM(CHARGING, has_rfid_tagged, turn_relay_off, OCCUPIED),
-		FSM_ITEM(CHARGING, has_remotely_stopped, turn_relay_off, OCCUPIED),
-		FSM_ITEM(CHARGING, is_suspended_by_ev, turn_relay_off, CHARGING),
-		FSM_ITEM(CHARGING, is_resumed_from_suspended, turn_relay_on, CHARGING),
-		FSM_ITEM(READY, has_hardware_error, NULL, UNAVAILABLE),
-		FSM_ITEM(OCCUPIED, has_hardware_error, NULL, UNAVAILABLE),
-		FSM_ITEM(CHARGING, has_hardware_error, NULL, UNAVAILABLE),
-		FSM_ITEM(UNAVAILABLE, is_hardware_recovered, NULL, READY),
-	};
+TEST(FSM, ShouldBeStateA_WhenInitialized) {
+	LONGS_EQUAL(A, fsm_state(&fsm));
+}
 
-	fsm_init(&fsm, items, sizeof(items) / sizeof(*items), 0);
+TEST(FSM, ShouldCheckFirstRegisteredEventFirst) {
+	mock().expectOneCall("is_state_b").andReturnValue(false);
+	mock().ignoreOtherCalls();
+	fsm_step(&fsm);
+}
 
-	mock().expectOneCall("is_plugged_in").andReturnValue(true);
+TEST(FSM, ShouldCheckSecondRegisteredEvent_WhenFirstEventReturnFalse) {
+	mock().expectOneCall("is_state_b").andReturnValue(false);
+	mock().expectOneCall("is_state_c").andReturnValue(false);
+	mock().ignoreOtherCalls();
 	fsm_step(&fsm);
-	mock().expectOneCall("is_plugged_in").andReturnValue(true);
-	mock().expectOneCall("turn_relay_on");
+}
+
+TEST(FSM, ShouldCheckAllEventsInThestate_WhenNoEventReturnTrue) {
+	mock().expectOneCall("is_state_b").andReturnValue(false);
+	mock().expectOneCall("is_state_c").andReturnValue(false);
 	fsm_step(&fsm);
-	mock().expectOneCall("is_plugged_out").andReturnValue(false);
-	mock().expectOneCall("has_rfid_tagged").andReturnValue(false);
-	mock().expectOneCall("has_remotely_stopped").andReturnValue(false);
-	mock().expectOneCall("is_suspended_by_ev").andReturnValue(true);
-	mock().expectOneCall("turn_relay_off");
+}
+
+TEST(FSM, ShouldCallAction_WhenEventReturnTrue) {
+	mock().expectOneCall("is_state_b").andReturnValue(true);
+	mock().expectOneCall("do_state_b");
 	fsm_step(&fsm);
-	mock().expectOneCall("is_plugged_out").andReturnValue(true);
-	mock().expectOneCall("turn_relay_off");
+}
+
+TEST(FSM, ShouldChangeState_WhenEventReturnTrue) {
+	mock().expectOneCall("is_state_b").andReturnValue(true);
+	mock().expectOneCall("do_state_b");
+	LONGS_EQUAL(B, fsm_step(&fsm));
+	LONGS_EQUAL(B, fsm_state(&fsm));
+}
+
+TEST(FSM, ShouldIgnoreNullAction_WhenEventReturnTrue) {
+	mock().expectOneCall("is_state_b").andReturnValue(false);
+	mock().expectOneCall("is_state_c").andReturnValue(true);
+	mock().expectOneCall("do_state_c");
+	fsm_step(&fsm);
+	mock().expectOneCall("is_state_a").andReturnValue(false);
+	mock().expectOneCall("is_state_b").andReturnValue(false);
+	mock().expectOneCall("is_state_c").andReturnValue(true);
+	fsm_step(&fsm);
+}
+
+TEST(FSM, ShouldCallCallback_WhenStateChange) {
+	fsm_set_state_change_cb(&fsm, on_state_change, 0);
+	mock().expectOneCall("on_state_change").withParameter("new_state", B)
+		.withParameter("prev_state", A);
+	mock().expectOneCall("is_state_b").andReturnValue(true);
+	mock().expectOneCall("do_state_b");
+	fsm_step(&fsm);
+}
+
+TEST(FSM, ShouldNotCallCallback_WhenStateIsNotChanged) {
+	fsm_set_state_change_cb(&fsm, on_state_change, 0);
+	mock().expectOneCall("is_state_b").andReturnValue(false);
+	mock().expectOneCall("is_state_c").andReturnValue(false);
+	fsm_step(&fsm);
+}
+
+TEST(FSM, ShouldIgnoreNullEvent) {
+	mock().expectOneCall("is_state_b").andReturnValue(false);
+	mock().expectOneCall("is_state_c").andReturnValue(false);
 	fsm_step(&fsm);
 }


### PR DESCRIPTION
This pull request introduces a new callback mechanism for state changes in the finite state machine (FSM) module. The most important changes include adding a new callback type, modifying the FSM structure to include callback fields, and implementing the callback functionality in the FSM step function.

Callback mechanism implementation:

* [`modules/fsm/include/libmcu/fsm.h`](diffhunk://#diff-921d067689e0987308aaf2b52ee98e07c9d217f8fd9b3a5d818b077afb0b51cdR31-R34): Added a new callback type `fsm_state_change_cb_t` and updated the `fsm` structure to include a callback function pointer `cb` and a context pointer `cb_ctx`. [[1]](diffhunk://#diff-921d067689e0987308aaf2b52ee98e07c9d217f8fd9b3a5d818b077afb0b51cdR31-R34) [[2]](diffhunk://#diff-921d067689e0987308aaf2b52ee98e07c9d217f8fd9b3a5d818b077afb0b51cdR55-R57)
* [`modules/fsm/include/libmcu/fsm.h`](diffhunk://#diff-921d067689e0987308aaf2b52ee98e07c9d217f8fd9b3a5d818b077afb0b51cdR71-R85): Added a new function `fsm_set_state_change_cb` to set the callback for state changes.

Callback functionality:

* [`modules/fsm/src/fsm.c`](diffhunk://#diff-d29a53c47d361e7f4d2952555b26998859db1bca461e3298534d03d9b1539cc0R53-R56): Implemented the callback invocation in the `fsm_step` function to call the callback whenever the state changes.
* [`modules/fsm/src/fsm.c`](diffhunk://#diff-d29a53c47d361e7f4d2952555b26998859db1bca461e3298534d03d9b1539cc0R65-R71): Defined the `fsm_set_state_change_cb` function to store the callback and its context in the FSM structure.