### PR TITLE
apptmr: add pre and post timeout hook functions

### DIFF
--- a/interfaces/apptmr/include/libmcu/apptmr.h
+++ b/interfaces/apptmr/include/libmcu/apptmr.h
@@ -149,16 +149,30 @@ int apptmr_cap(void);
 int apptmr_len(void);
 
 /**
- * @brief Global timeout hook function for application timer.
+ * @brief Global timeout pre hook function for application timer.
  *
  * This function is called whenever any registered application timer
  * reaches its timeout. It serves as a common hook that can be used to
  * perform actions that need to be executed whenever any timer expires.
+ * This function is called before the global timeout callback is executed.
  *
  * @param self Pointer to the application timer instance that triggered
  *             the timeout.
  */
-void apptmr_global_timeout_hook(struct apptmr *self);
+void apptmr_global_pre_timeout_hook(struct apptmr *self);
+
+/**
+ * @brief Global timeout post hook function for application timer.
+ *
+ * This function is called whenever any registered application timer
+ * reaches its timeout. It serves as a common hook that can be used to
+ * perform actions that need to be executed whenever any timer expires.
+ * This function is called after the global timeout callback is executed.
+ *
+ * @param self Pointer to the application timer instance that triggered
+ *             the timeout.
+ */
+void apptmr_global_post_timeout_hook(struct apptmr *self);
 
 #if defined(UNIT_TEST)
 /**

--- a/ports/esp-idf/apptmr.c
+++ b/ports/esp-idf/apptmr.c
@@ -49,11 +49,13 @@ static void callback_wrapper(void *arg)
 {
 	struct apptmr *p = (struct apptmr *)arg;
 
-	apptmr_global_timeout_hook(p);
+	apptmr_global_pre_timeout_hook(p);
 
 	if (p && p->callback) {
 		(*p->callback)(p, p->arg);
 	}
+
+	apptmr_global_post_timeout_hook(p);
 }
 
 static void trigger(struct apptmr *self)


### PR DESCRIPTION
This pull request includes changes to the application timer (`apptmr`) module to introduce pre and post timeout hooks. The most important changes are the renaming of the existing global timeout hook function and the addition of new pre and post timeout hook functions.

Changes to the application timer hooks:

* [`interfaces/apptmr/include/libmcu/apptmr.h`](diffhunk://#diff-ea4403f362739b13eab849c86e32dd4d5931693ed35046fddcbd815ec6391098L152-R175): Renamed the existing `apptmr_global_timeout_hook` function to `apptmr_global_pre_timeout_hook` and added a new `apptmr_global_post_timeout_hook` function. Updated the documentation to reflect these changes.
* [`ports/esp-idf/apptmr.c`](diffhunk://#diff-5d2bae2b0a15b00d41c3ccee5375b5b820c0cadd8d6a38d9e67d87cce5477a6dL52-R58): Updated the `callback_wrapper` function to call the new `apptmr_global_pre_timeout_hook` before the timer callback and the new `apptmr_global_post_timeout_hook` after the timer callback.