### PR TITLE
common/ringbuf: fix offset handling in read_core

### DIFF
--- a/modules/common/src/ringbuf.c
+++ b/modules/common/src/ringbuf.c
@@ -46,7 +46,7 @@ static void initialize(struct ringbuf *handle, const size_t bufsize)
 static uint8_t *get_pointer(const struct ringbuf *handle,
 		const size_t offset, size_t *contiguous)
 {
-	size_t index = GET_INDEX(handle->outdex+offset, handle->capacity);
+	size_t index = GET_INDEX(handle->outdex + offset, handle->capacity);
 	uint8_t *p = &handle->buffer[index];
 
 	if (offset >= get_length(handle)) {
@@ -70,9 +70,8 @@ static size_t read_core(const struct ringbuf *handle,
 	size_t bytes_read = 0;
 
 	if (p) {
-		const size_t len = MIN(get_length(handle), bufsize);
-		const size_t remained = (contiguous < len + offset)?
-			len - (contiguous + offset) : 0;
+		const size_t len = MIN(get_length(handle) - offset, bufsize);
+		const size_t remained = contiguous < len? len - contiguous : 0;
 		const size_t cut = len - remained;
 
 		memcpy(buf, p, cut);

--- a/tests/src/common/ringbuf_test.cpp
+++ b/tests/src/common/ringbuf_test.cpp
@@ -97,7 +97,7 @@ TEST(RingBuffer, read_ShouldReturnLengthOfBytesRead_WhenLargerBufferGivenWithOff
 	const uint8_t test_data[] = "1234567890123";
 	uint8_t buf[80] = { 0, };
 	ringbuf_write(&ringbuf_obj, test_data, sizeof(test_data));
-	LONGS_EQUAL(sizeof(test_data), ringbuf_read(&ringbuf_obj, 1, buf, sizeof(test_data)));
+	LONGS_EQUAL(sizeof(test_data)-1, ringbuf_read(&ringbuf_obj, 1, buf, sizeof(test_data)));
 }
 
 TEST(RingBuffer, peek_ShouldReturnDataSizeRead_WhenSuccessfulWithOffset) {


### PR DESCRIPTION
This pull request includes a change to the `read_core` function in the `ringbuf.c` file to correct the calculation of the `len` and `remained` variables.

* [`modules/common/src/ringbuf.c`](diffhunk://#diff-2c724b5849dee4299cf6d31c22677d6033b58bddab276ca3240867d78f0736acL73-R74): Modified the `read_core` function to correctly calculate the `len` and `remained` variables by adjusting the `len` calculation to account for the `offset` and simplifying the `remained` calculation.