### PR TITLE
metrics: add metricfs module for metric storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ Any feedback would be appreciated.
 * [RateLim](modules/ratelim)
 * [Retry with exponential backoff](modules/retry)
 * [Runner](modules/runner)
-* [Time Extension](modules/common)
-* [Trace](modules/trace)
 
 ## Interfaces
 * [ADC](interfaces/adc)

--- a/modules/metrics/include/libmcu/metricfs.h
+++ b/modules/metrics/include/libmcu/metricfs.h
@@ -1,0 +1,204 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef LIBMCU_METRICFS_H
+#define LIBMCU_METRICFS_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include "libmcu/kvstore.h"
+
+#if !defined(METRICFS_ID_PREFIX)
+#define METRICFS_ID_PREFIX	"metric"
+#endif
+#if !defined(METRICFS_ID_MAXLEN)
+#define METRICFS_ID_MAXLEN	15
+#endif
+
+struct metricfs;
+
+typedef uint16_t metricfs_id_t;
+
+/**
+ * @typedef metricfs_iterator_t
+ * @brief A function pointer type for iterating over metric file system entries.
+ *
+ * This type defines a function pointer for a callback function used to iterate
+ * over entries in the metric file system.
+ *
+ * @param[in] id The identifier of the metric entry.
+ * @param[in] data A pointer to the data associated with the metric entry.
+ * @param[in] datasize The size of the data in bytes.
+ * @param[in] ctx A user-defined context pointer that can be used to pass
+ *            additional information to the callback function.
+ */
+typedef void (*metricfs_iterator_t)(const metricfs_id_t id,
+		const void *data, const size_t datasize, void *ctx);
+
+/**
+ * @brief Creates a metric file system instance.
+ *
+ * This function initializes and returns a new metric file system instance.
+ * This function initializes and returns a new metric file system instance.
+ *
+ * @note This function does not open the namespace internally. The namespace
+ * must be opened before using the metric file system instance.
+ *
+ * @param[in] kvstore A pointer to the key-value store to be used by the metric
+ *            file system.
+ * @param[in] prefix A string representing the prefix for the metrics.
+ * @param[in] max_metrics The maximum number of metrics that can be stored in
+ *            the metric file system.
+ *
+ * @return A pointer to the newly created metric file system instance.
+ */
+struct metricfs *metricfs_create(struct kvstore *kvstore,
+		const char *prefix, const size_t max_metrics);
+
+/**
+ * @brief Destroys a metric file system instance.
+ *
+ * This function releases all resources associated with the given metric file
+ * system instance.
+ *
+ * @param[in] fs A pointer to the metric file system instance to be destroyed.
+ */
+void metricfs_destroy(struct metricfs *fs);
+
+/**
+ * @brief Writes data to the metric file system.
+ *
+ * This function writes the given data to the metric file system.
+ *
+ * @param[in] fs A pointer to the metric file system instance.
+ * @param[in] data A pointer to the data to be written.
+ * @param[in] datasize The size of the data in bytes.
+ * @param[out] id A pointer to store the generated id. NULL can be passed if id
+ *             is not needed.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
+int metricfs_write(struct metricfs *fs,
+		const void *data, const size_t datasize, metricfs_id_t *id);
+
+/**
+ * @brief Counts the number of metrics in the metric file system.
+ *
+ * This function returns the number of metrics currently stored in the metric
+ * file system.
+ *
+ * @param[in] fs A pointer to the metric file system instance.
+ *
+ * @return The number of metrics in the metric file system.
+ */
+uint16_t metricfs_count(const struct metricfs *fs);
+
+/**
+ * @brief Iterates over metrics in the metric file system.
+ *
+ * This function iterates over the metrics stored in the metric file system and
+ * calls the provided callback function for each metric.
+ *
+ * @param[in] fs A pointer to the metric file system instance.
+ * @param[in] cb The callback function to be called for each metric.
+ * @param[in] cb_ctx A user-defined context pointer to be passed to the callback
+ *            function.
+ * @param[out] buf A buffer to store the data of each metric during iteration.
+ * @param[in] bufsize The size of the buffer in bytes.
+ * @param[in] max_metrics The maximum number of metrics to iterate over.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
+int metricfs_iterate(struct metricfs *fs,
+		metricfs_iterator_t cb, void *cb_ctx,
+		void *buf, const size_t bufsize, const size_t max_metrics);
+
+/**
+ * @brief Peeks at data in the metric file system without removing it.
+ *
+ * This function reads the data associated with the specified id from the metric
+ * file system without removing the data.
+ *
+ * @param[in] fs A pointer to the metric file system instance.
+ * @param[in] id The id of the metric to be peeked at.
+ * @param[out] buf A buffer to store the peeked data.
+ * @param[in] bufsize The size of the buffer in bytes.
+ *
+ * @return The number of bytes read on success, or a negative error code on
+ *         failure.
+ */
+int metricfs_peek(struct metricfs *fs,
+		const metricfs_id_t id, void *buf, const size_t bufsize);
+
+/**
+ * @brief Peeks at the first metric in the metric file system without removing
+ * it.
+ *
+ * This function reads the data of the first metric in the metric file system
+ * without removing it.
+ *
+ * @param[in] fs A pointer to the metric file system instance.
+ * @param[out] buf A buffer to store the peeked data.
+ * @param[in] bufsize The size of the buffer in bytes.
+ * @param[out] id A pointer to store the id of the first metric. If null, the id
+ *             is ignored. Null input is acceptable.
+ *
+ * @return The number of bytes read on success, or a negative error code on
+ *         failure.
+ */
+int metricfs_peek_first(struct metricfs *fs,
+		void *buf, const size_t bufsize, metricfs_id_t *id);
+
+/**
+ * @brief Reads the first metric from the metric file system.
+ *
+ * This function reads the data of the first metric in the metric file system
+ * and removes it.
+ *
+ * @param[in] fs A pointer to the metric file system instance.
+ * @param[out] buf A buffer to store the read data.
+ * @param[in] bufsize The size of the buffer in bytes.
+ * @param[out] id A pointer to store the id of the first metric. If null, the id
+ *             is ignored. Null input is acceptable.
+ *
+ * @return The number of bytes read on success, or a negative error code on
+ *         failure.
+ */
+int metricfs_read_first(struct metricfs *fs,
+		void *buf, const size_t bufsize, metricfs_id_t *id);
+
+/**
+ * @brief Deletes the first metric from the metric file system.
+ *
+ * This function deletes the first metric in the metric file system.
+ *
+ * @param[in] fs A pointer to the metric file system instance.
+ * @param[out] id A pointer to store the id of the deleted metric. If null, the
+ *             id is ignored. Null input is acceptable.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
+int metricfs_del_first(struct metricfs *fs, metricfs_id_t *id);
+
+/**
+ * @brief Clears all metrics from the metric file system.
+ *
+ * This function removes all metrics from the metric file system.
+ *
+ * @param[in] fs A pointer to the metric file system instance.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
+int metricfs_clear(struct metricfs *fs);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* LIBMCU_METRICFS_H */

--- a/modules/metrics/src/metricfs.c
+++ b/modules/metrics/src/metricfs.c
@@ -1,0 +1,310 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "libmcu/metricfs.h"
+
+#include <string.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdbool.h>
+
+#define PREFIX_MAXLEN		(METRICFS_ID_MAXLEN - 6) /* metricfs_id_t
+					represents 5 digits + 1 for slash. */
+struct metricfs {
+	struct kvstore *kvstore;
+	const char *prefix;
+	size_t max_metrics;
+
+	metricfs_id_t index;
+	metricfs_id_t outdex;
+};
+
+struct iterator_ctx {
+	metricfs_iterator_t cb;
+	void *cb_ctx;
+	void *buf;
+	size_t bufsize;
+
+	metricfs_id_t id;
+};
+
+typedef bool (*iterator_fn_t)(struct metricfs *fs,
+		const char *keystr, struct iterator_ctx *ctx);
+
+static int read_index(struct metricfs *fs, metricfs_id_t *index)
+{
+	char keystr[METRICFS_ID_MAXLEN+1];
+	snprintf(keystr, sizeof(keystr)-1, "%s/index", fs->prefix);
+	int err = kvstore_read(fs->kvstore, keystr, index, sizeof(*index));
+	if (err == -ENOENT) {
+		*index = 0;
+		err = 0;
+	}
+	return err;
+}
+
+static int read_outdex(struct metricfs *fs, metricfs_id_t *outdex)
+{
+	char keystr[METRICFS_ID_MAXLEN+1];
+	snprintf(keystr, sizeof(keystr)-1, "%s/outdex", fs->prefix);
+	int err = kvstore_read(fs->kvstore, keystr, outdex, sizeof(*outdex));
+	if (err == -ENOENT) {
+		*outdex = 0;
+		err = 0;
+	}
+	return err;
+}
+
+static int update_index(struct metricfs *fs, const metricfs_id_t index)
+{
+	char keystr[METRICFS_ID_MAXLEN+1];
+	snprintf(keystr, sizeof(keystr)-1, "%s/index", fs->prefix);
+	return kvstore_write(fs->kvstore, keystr, &index, sizeof(index));
+}
+
+static int update_outdex(struct metricfs *fs, const metricfs_id_t outdex)
+{
+	char keystr[METRICFS_ID_MAXLEN+1];
+	snprintf(keystr, sizeof(keystr)-1, "%s/outdex", fs->prefix);
+	return kvstore_write(fs->kvstore, keystr, &outdex, sizeof(outdex));
+}
+
+static uint16_t count_metrics(const struct metricfs *fs)
+{
+	return fs->index - fs->outdex;
+}
+
+static int peek_first(struct metricfs *fs, void *buf, const size_t bufsize)
+{
+	if (count_metrics(fs) == 0) {
+		return -ENOENT;
+	}
+
+	char keystr[METRICFS_ID_MAXLEN+1];
+	snprintf(keystr, sizeof(keystr)-1, "%s/%u", fs->prefix, fs->outdex);
+	return kvstore_read(fs->kvstore, keystr, buf, bufsize);
+}
+
+static int delete_first(struct metricfs *fs)
+{
+	if (count_metrics(fs) == 0) {
+		return -ENOENT;
+	}
+
+	char keystr[METRICFS_ID_MAXLEN+1];
+	snprintf(keystr, sizeof(keystr)-1, "%s/%u", fs->prefix, fs->outdex);
+	int err = kvstore_clear(fs->kvstore, keystr);
+
+	if (err < 0 && err != -ENOENT) {
+		return err;
+	}
+
+	if ((err = update_outdex(fs, fs->outdex + 1)) == sizeof(fs->outdex)) {
+		fs->outdex += 1;
+		return 0;
+	}
+
+	return err;
+}
+
+static bool on_read_iteration(struct metricfs *fs,
+		const char *keystr, struct iterator_ctx *ctx)
+{
+	int err = kvstore_read(fs->kvstore, keystr, ctx->buf, ctx->bufsize);
+
+	if (err < 0) {
+		return false;
+	} else if (ctx->cb) {
+		(*ctx->cb)(ctx->id, ctx->buf, (size_t)err, ctx->cb_ctx);
+	}
+
+	return true;
+}
+
+static bool on_clear_iteration(struct metricfs *fs,
+		const char *keystr, struct iterator_ctx *ctx)
+{
+	(void)ctx;
+
+	if (kvstore_clear(fs->kvstore, keystr) >= 0) {
+		fs->outdex += 1;
+		return true;
+	}
+
+	return false;
+}
+
+static int iterate(struct metricfs *fs, iterator_fn_t fn,
+		struct iterator_ctx *ctx, const uint16_t max_count)
+{
+	const metricfs_id_t outdex = fs->outdex;
+
+	for (uint16_t i = 0; i < max_count; i++) {
+		const metricfs_id_t id = outdex + i;
+		char keystr[METRICFS_ID_MAXLEN+1];
+
+		snprintf(keystr, sizeof(keystr)-1, "%s/%u", fs->prefix, id);
+		ctx->id = id;
+
+		if (!(*fn)(fs, keystr, ctx)) {
+			return -EIO;
+		}
+	}
+
+	return 0;
+}
+
+int metricfs_write(struct metricfs *fs,
+		const void *data, const size_t datasize, metricfs_id_t *id)
+{
+	char keystr[METRICFS_ID_MAXLEN+1];
+	int err;
+
+	if (count_metrics(fs) >= fs->max_metrics) {
+		return -ENOSPC;
+	}
+
+	snprintf(keystr, sizeof(keystr)-1, "%s/%u", fs->prefix, fs->index);
+	err = kvstore_write(fs->kvstore, keystr, data, datasize);
+	if ((size_t)err != datasize) {
+		return err;
+	}
+
+	if ((err = update_index(fs, fs->index + 1)) == sizeof(fs->index)) {
+		if (id) {
+			*id = fs->index;
+		}
+		fs->index += 1;
+
+		return 0;
+	}
+
+	return err;
+}
+
+uint16_t metricfs_count(const struct metricfs *fs)
+{
+	return count_metrics(fs);
+}
+
+int metricfs_iterate(struct metricfs *fs,
+		metricfs_iterator_t cb, void *cb_ctx,
+		void *buf, const size_t bufsize, const size_t max_metrics)
+{
+	struct iterator_ctx ctx = {
+		.cb = cb,
+		.cb_ctx = cb_ctx,
+		.buf = buf,
+		.bufsize = bufsize,
+	};
+	uint16_t n = count_metrics(fs);
+
+	if (n == 0) {
+		return -ENOENT;
+	}
+
+	if (max_metrics > 0 && (uint16_t)max_metrics < n) {
+		n = (uint16_t)max_metrics;
+	}
+
+	return iterate(fs, on_read_iteration, &ctx, n);
+}
+
+int metricfs_peek(struct metricfs *fs,
+		const metricfs_id_t id, void *buf, const size_t bufsize)
+{
+	char keystr[METRICFS_ID_MAXLEN+1];
+	snprintf(keystr, sizeof(keystr)-1, "%s/%u", fs->prefix, id);
+	return kvstore_read(fs->kvstore, keystr, buf, bufsize);
+}
+
+int metricfs_peek_first(struct metricfs *fs,
+		void *buf, const size_t bufsize, metricfs_id_t *id)
+{
+	int err = peek_first(fs, buf, bufsize);
+
+	if (err > 0 && id) {
+		*id = fs->outdex;
+	}
+
+	return err;
+}
+
+int metricfs_read_first(struct metricfs *fs,
+		void *buf, const size_t bufsize, metricfs_id_t *id)
+{
+	int err = peek_first(fs, buf, bufsize);
+
+	if (err > 0 || err == -ENOENT) {
+		if (err > 0 && id) {
+			*id = fs->outdex;
+		}
+
+		if (delete_first(fs) < 0) {
+			err = -EIO;
+		}
+	}
+
+	return err;
+}
+
+int metricfs_del_first(struct metricfs *fs, metricfs_id_t *id)
+{
+	if (id) {
+		*id = fs->outdex;
+	}
+
+	return delete_first(fs);
+}
+
+int metricfs_clear(struct metricfs *fs)
+{
+	struct iterator_ctx ctx = {
+		.buf = NULL,
+		.bufsize = 0,
+	};
+	const uint16_t n = count_metrics(fs);
+
+	if (n == 0) {
+		return -ENOENT;
+	}
+
+	int err = iterate(fs, on_clear_iteration, &ctx, n);
+	err |= update_outdex(fs, fs->outdex);
+
+	return (err >= 0)? 0 : err;
+}
+
+struct metricfs *metricfs_create(struct kvstore *kvstore,
+		const char *prefix, const size_t max_metrics)
+{
+	static struct metricfs fs;
+
+	if (!kvstore || !prefix || max_metrics == 0 ||
+			strlen(prefix) > PREFIX_MAXLEN) {
+		return NULL;
+	}
+
+	fs = (struct metricfs) {
+		.kvstore = kvstore,
+		.prefix = prefix,
+		.max_metrics = max_metrics,
+		.index = 0,
+		.outdex = 0,
+	};
+
+	if (read_index(&fs, &fs.index) < 0 ||
+			read_outdex(&fs, &fs.outdex) < 0) {
+		return NULL;
+	}
+
+	return &fs;
+}
+
+void metricfs_destroy(struct metricfs *fs)
+{
+	memset(fs, 0, sizeof(*fs));
+}

--- a/projects/runner.mk
+++ b/projects/runner.mk
@@ -3,7 +3,8 @@
 include projects/version.mk
 include projects/toolchain.mk
 
-LIBMCU_MODULES ?= $(patsubst modules/%, %, $(wildcard modules/*))
+excludes := trace
+LIBMCU_MODULES ?= $(filter-out $(excludes), $(patsubst modules/%, %, $(wildcard modules/*)))
 LIBMCU_INTERFACES ?= $(patsubst interfaces/%, %, $(wildcard interfaces/*))
 include projects/modules.mk
 include projects/interfaces.mk

--- a/projects/toolchain.mk
+++ b/projects/toolchain.mk
@@ -36,6 +36,7 @@ LIBMCU_WARNING_FLAGS ?= \
 	-Werror \
 	-Wall \
 	-Wextra \
+	-Wpedantic \
 	-Wc++-compat \
 	-Wformat=2 \
 	-Wmissing-prototypes \
@@ -61,13 +62,24 @@ LIBMCU_WARNING_FLAGS ?= \
 	-Wstrict-overflow=5 \
 	-Wno-long-long \
 	-Wswitch-default \
-	-Wstack-usage=$(STACK_LIMIT)
+	\
+	-Wno-error=format-nonliteral \
+
 	#-Wformat-truncation=2
 	#-Wformat-overflow
 	#-Wabi=11 -Wlogical-op
-	#-Wpedantic
 	#-Wnested-externs
 	#-Wswitch-enum
+
+COMPILER := $(shell $(CC) --version 2>/dev/null | head -n 1 | grep -i clang >/dev/null && echo clang || echo gcc)
+ifeq ($(COMPILER), clang)
+else
+LIBMCU_WARNING_FLAGS += -Wstack-usage=$(STACK_LIMIT) -Wno-error=inline
+endif
+
+ifeq ($(shell uname), Darwin)
+else
+endif
 
 ## Linker options
 LIBMCU_LDFLAGS ?= \

--- a/tests/runners/metrics/metricfs.mk
+++ b/tests/runners/metrics/metricfs.mk
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+
+COMPONENT_NAME = metricfs
+
+SRC_FILES = \
+	../modules/metrics/src/metricfs.c \
+
+TEST_SRC_FILES = \
+	src/metrics/metricfs_test.cpp \
+	src/test_all.cpp \
+
+INCLUDE_DIRS = \
+	$(CPPUTEST_HOME)/include \
+	../modules/metrics/include \
+	../interfaces/kvstore/include \
+
+MOCKS_SRC_DIRS =
+CPPUTEST_CPPFLAGS =
+
+include runners/MakefileRunner

--- a/tests/src/metrics/metricfs_test.cpp
+++ b/tests/src/metrics/metricfs_test.cpp
@@ -1,0 +1,380 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include "CppUTest/TestHarness.h"
+#include "CppUTestExt/MockSupport.h"
+
+#include "libmcu/metricfs.h"
+
+#define MAX_METRICS		3
+
+struct kvstore {
+	kvstore_api api;
+};
+
+static int fake_write(struct kvstore *self,
+		const char *key, const void *value, size_t size) {
+	return mock().actualCall("fake_write")
+		.withParameter("key", key)
+		.withMemoryBufferParameter("value", (const uint8_t *)value, size)
+		.returnIntValue();
+}
+static int fake_read(struct kvstore *self,
+		const char *key, void *buf, size_t size) {
+	return mock().actualCall("fake_read")
+		.withParameter("key", key)
+		.withOutputParameter("buf", buf)
+		.returnIntValue();
+}
+static int fake_clear(struct kvstore *self, const char *key) {
+	return mock().actualCall("fake_clear")
+		.withParameter("key", key)
+		.returnIntValue();
+}
+
+static struct kvstore fake_kvstore = {
+	.api = {
+		.write = fake_write,
+		.read = fake_read,
+		.clear = fake_clear,
+	},
+};
+
+static void on_iterate(const metricfs_id_t id, const void *data, const size_t datasize, void *ctx) {
+	mock().actualCall("on_iterate").withParameter("id", (metricfs_id_t)id);
+}
+
+TEST_GROUP(metricfs) {
+	struct metricfs *fs;
+	uint16_t index;
+	uint16_t outdex;
+
+	void setup(void) {
+		index = 0;
+		outdex = 0;
+
+		mock().expectOneCall("fake_read")
+			.withParameter("key", "prefix/index")
+			.withOutputParameterReturning("buf", &index, sizeof(index))
+			.andReturnValue((int)sizeof(index));
+		mock().expectOneCall("fake_read")
+			.withParameter("key", "prefix/outdex")
+			.withOutputParameterReturning("buf", &outdex, sizeof(outdex))
+			.andReturnValue((int)sizeof(outdex));
+		fs = metricfs_create(&fake_kvstore, "prefix", MAX_METRICS);
+	}
+	void teardown(void) {
+		mock().checkExpectations();
+		mock().clear();
+
+		metricfs_destroy(fs);
+	}
+
+	void expect_index_write(const char *idstr, const uint8_t *data,
+			const size_t datasize) {
+		index += 1;
+		mock().expectOneCall("fake_write")
+			.withParameter("key", idstr)
+			.withMemoryBufferParameter("value", data, datasize)
+			.andReturnValue((int)datasize);
+		mock().expectOneCall("fake_write")
+			.withParameter("key", "prefix/index")
+			.withMemoryBufferParameter("value", (const uint8_t *)&index, sizeof(index))
+			.andReturnValue((int)sizeof(index));
+	}
+	void expect_outdex_write(const char *idstr, const uint8_t *data,
+			const size_t datasize) {
+		outdex += 1;
+		mock().expectOneCall("fake_clear")
+			.withParameter("key", idstr)
+			.andReturnValue(0);
+		mock().expectOneCall("fake_write")
+			.withParameter("key", "prefix/outdex")
+			.withMemoryBufferParameter("value", (const uint8_t *)&outdex, sizeof(outdex))
+			.andReturnValue((int)sizeof(outdex));
+	}
+	void expect_peek(const char *idstr, const uint8_t *data,
+			const size_t datasize) {
+		mock().expectOneCall("fake_read")
+			.withParameter("key", idstr)
+			.withOutputParameterReturning("buf", data, datasize)
+			.andReturnValue((int)datasize);
+	}
+	void expect_read(const char *idstr, const uint8_t *data,
+			const size_t datasize) {
+		mock().expectOneCall("fake_read")
+			.withParameter("key", idstr)
+			.withOutputParameterReturning("buf", data, datasize)
+			.andReturnValue((int)datasize);
+		expect_outdex_write(idstr, data, datasize);
+	}
+};
+
+TEST(metricfs, clear_ShouldReturnENOENT_WhenNoMetrics) {
+	LONGS_EQUAL(-ENOENT, metricfs_clear(fs));
+}
+TEST(metricfs, del_first_ShouldReturnENOENT_WhenNoMetrics) {
+	LONGS_EQUAL(-ENOENT, metricfs_del_first(fs, NULL));
+}
+TEST(metricfs, peek_first_ShouldReturnENOENT_WhenNoMetrics) {
+	uint8_t buf[8];
+	LONGS_EQUAL(-ENOENT, metricfs_peek_first(fs, buf, sizeof(buf), NULL));
+}
+TEST(metricfs, peek_ShouldReturnENOENT_WhenNoMatchingMetrics) {
+	uint8_t buf[8];
+	mock().expectOneCall("fake_read")
+		.withParameter("key", "prefix/0")
+		.ignoreOtherParameters()
+		.andReturnValue(-ENOENT);
+	LONGS_EQUAL(-ENOENT, metricfs_peek(fs, 0, buf, sizeof(buf)));
+}
+TEST(metricfs, count_ShouldReturnZero_WhenNoMetrics) {
+	LONGS_EQUAL(0, metricfs_count(fs));
+}
+TEST(metricfs, iterate_ShouldReturnENOENT_WhenNoMetrics) {
+	LONGS_EQUAL(-ENOENT, metricfs_iterate(fs, on_iterate, NULL, NULL, 0, 0));
+}
+
+TEST(metricfs, write_ShouldWriteInStorage_WhenCalled) {
+	uint8_t data[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+	expect_index_write("prefix/0", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+}
+TEST(metricfs, write_ShouldReturnWrttenId_WhenIdNotNull) {
+	uint8_t data[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+	metricfs_id_t id;
+	expect_index_write("prefix/0", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), &id));
+	LONGS_EQUAL(0, id);
+}
+TEST(metricfs, write_ShouldIncrementIndex_WhenCalled) {
+	uint8_t data[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+	expect_index_write("prefix/0", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+	LONGS_EQUAL(1, metricfs_count(fs));
+}
+TEST(metricfs, write_ShouldReturnENOSPC_WhenStorageFull) {
+	uint8_t data[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+
+	for (metricfs_id_t i = 0; i < MAX_METRICS; i++) {
+		char idstr[32];
+		snprintf(idstr, sizeof(idstr)-1, "prefix/%u", i);
+		expect_index_write(idstr, data, sizeof(data));
+		LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+	}
+	LONGS_EQUAL(-ENOSPC, metricfs_write(fs, data, sizeof(data), NULL));
+}
+
+TEST(metricfs, del_first_ShouldDeleteFirstMetric_WhenCalled) {
+	uint8_t data[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+	expect_index_write("prefix/0", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+	expect_index_write("prefix/1", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+
+	metricfs_id_t id;
+	expect_outdex_write("prefix/0", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_del_first(fs, &id));
+	LONGS_EQUAL(0, id);
+}
+
+TEST(metricfs, peek_first_ShouldPeekFirstMetric_WhenCalled) {
+	uint8_t data[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+	expect_index_write("prefix/0", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+	expect_index_write("prefix/1", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+
+	uint8_t buf[8];
+	metricfs_id_t id;
+	expect_peek("prefix/0", data, sizeof(data));
+	LONGS_EQUAL(8, metricfs_peek_first(fs, buf, sizeof(buf), &id));
+	MEMCMP_EQUAL(data, buf, sizeof(data));
+	LONGS_EQUAL(0, id);
+}
+
+TEST(metricfs, read_first_ShouldReadFirstMetric_WhenCalled) {
+	uint8_t data[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+	expect_index_write("prefix/0", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+	expect_index_write("prefix/1", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+
+	uint8_t buf[8];
+	metricfs_id_t id;
+	expect_read("prefix/0", data, sizeof(data));
+	LONGS_EQUAL(8, metricfs_read_first(fs, buf, sizeof(buf), &id));
+	MEMCMP_EQUAL(data, buf, sizeof(data));
+	LONGS_EQUAL(0, id);
+}
+
+TEST(metricfs, ShouldIncreaseIndexAndOutdexMonotonicly_WhenWriteAndReadRepeatedly) {
+	uint8_t data[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+	uint8_t buf[8];
+	metricfs_id_t id;
+
+	for (metricfs_id_t i = 0; i < MAX_METRICS*2; i++) {
+		char idstr[32];
+		snprintf(idstr, sizeof(idstr)-1, "prefix/%u", i);
+
+		expect_index_write(idstr, data, sizeof(data));
+		LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+		expect_read(idstr, data, sizeof(data));
+		LONGS_EQUAL(8, metricfs_read_first(fs, buf, sizeof(buf), &id));
+		LONGS_EQUAL(i, id);
+	}
+}
+
+TEST(metricfs, ShouldStillWork_WhenIndexWrapAround) {
+	metricfs_destroy(fs);
+	index = 3;
+	outdex = 0xfffe;
+
+	mock().expectOneCall("fake_read")
+		.withParameter("key", "prefix/index")
+		.withOutputParameterReturning("buf", &index, sizeof(index))
+		.andReturnValue((int)sizeof(index));
+	mock().expectOneCall("fake_read")
+		.withParameter("key", "prefix/outdex")
+		.withOutputParameterReturning("buf", &outdex, sizeof(outdex))
+		.andReturnValue((int)sizeof(outdex));
+	fs = metricfs_create(&fake_kvstore, "prefix", 10);
+
+	LONGS_EQUAL(5, metricfs_count(fs));
+
+	metricfs_id_t id;
+	uint8_t buf[8];
+	uint8_t data[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+	expect_index_write("prefix/3", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+
+	expect_read("prefix/65534", data, sizeof(data));
+	LONGS_EQUAL(8, metricfs_read_first(fs, buf, sizeof(buf), &id));
+	LONGS_EQUAL(65534, id);
+}
+
+TEST(metricfs, ShouldReturnZeroIndex_WhenIndexIsNotCreatedYet) {
+	metricfs_destroy(fs);
+	mock().expectOneCall("fake_read")
+		.withParameter("key", "prefix/index")
+		.ignoreOtherParameters()
+		.andReturnValue(-ENOENT);
+	mock().expectOneCall("fake_read")
+		.withParameter("key", "prefix/outdex")
+		.ignoreOtherParameters()
+		.andReturnValue(-ENOENT);
+	fs = metricfs_create(&fake_kvstore, "prefix", 10);
+	CHECK(fs != NULL);
+
+	metricfs_id_t id;
+	uint8_t buf[8];
+	uint8_t data[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+	expect_index_write("prefix/0", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+	expect_read("prefix/0", data, sizeof(data));
+	LONGS_EQUAL(8, metricfs_read_first(fs, buf, sizeof(buf), &id));
+	LONGS_EQUAL(0, id);
+}
+
+TEST(metricfs, write_ShouldNotIncreaseIndex_WhenWriteFailed) {
+	uint8_t data[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+	expect_index_write("prefix/0", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+	expect_index_write("prefix/1", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+
+	mock().expectOneCall("fake_write")
+		.withParameter("key", "prefix/2")
+		.ignoreOtherParameters()
+		.andReturnValue(-ENOMEM);
+	LONGS_EQUAL(-ENOMEM, metricfs_write(fs, data, sizeof(data), NULL));
+	LONGS_EQUAL(2, metricfs_count(fs));
+}
+TEST(metricfs, write_ShouldNotIncreaseIndex_WhenIndexWriteFailed) {
+	uint8_t data[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+	expect_index_write("prefix/0", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+	expect_index_write("prefix/1", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+
+	mock().expectOneCall("fake_write")
+		.withParameter("key", "prefix/2")
+		.ignoreOtherParameters()
+		.andReturnValue((int)sizeof(data));
+	mock().expectOneCall("fake_write")
+		.withParameter("key", "prefix/index")
+		.ignoreOtherParameters()
+		.andReturnValue(-ENOMEM);
+	LONGS_EQUAL(-ENOMEM, metricfs_write(fs, data, sizeof(data), NULL));
+	LONGS_EQUAL(2, metricfs_count(fs));
+}
+
+TEST(metricfs, iterate_ShouldCallCallback_WhenMetricsExist) {
+	uint8_t buf[8];
+	uint8_t data[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+	expect_index_write("prefix/0", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+	expect_index_write("prefix/1", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+
+	expect_peek("prefix/0", data, sizeof(data));
+	expect_peek("prefix/1", data, sizeof(data));
+	mock().expectOneCall("on_iterate").withParameter("id", 0);
+	mock().expectOneCall("on_iterate").withParameter("id", 1);
+	LONGS_EQUAL(0, metricfs_iterate(fs, on_iterate, NULL, buf, sizeof(buf), MAX_METRICS));
+}
+
+TEST(metricfs, clear_ShouldClearAllMetrics_WhenCalled) {
+	uint8_t data[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+	expect_index_write("prefix/0", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+	expect_index_write("prefix/1", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+
+	outdex = 2;
+	mock().expectOneCall("fake_clear")
+		.withParameter("key", "prefix/0")
+		.andReturnValue(0);
+	mock().expectOneCall("fake_clear")
+		.withParameter("key", "prefix/1")
+		.andReturnValue(0);
+	mock().expectOneCall("fake_write")
+		.withParameter("key", "prefix/outdex")
+		.withMemoryBufferParameter("value", (const uint8_t *)&outdex, sizeof(outdex))
+		.andReturnValue((int)sizeof(outdex));
+	LONGS_EQUAL(0, metricfs_clear(fs));
+	LONGS_EQUAL(0, metricfs_count(fs));
+}
+
+TEST(metricfs, ShouldNotIncreaseOutdex_WhenDeleteFailed) {
+	uint8_t data[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+	expect_index_write("prefix/0", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+	expect_index_write("prefix/1", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+
+	mock().expectOneCall("fake_clear")
+		.withParameter("key", "prefix/0")
+		.andReturnValue(-ENOMEM);
+	LONGS_EQUAL(-ENOMEM, metricfs_del_first(fs, NULL));
+	LONGS_EQUAL(2, metricfs_count(fs));
+}
+
+/* when item deleted successfully, but outdex write failed */
+TEST(metricfs, ShouldIncreaseOutdex_WhenReadReturnNOENT) {
+	uint8_t data[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+	expect_index_write("prefix/0", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+	expect_index_write("prefix/1", data, sizeof(data));
+	LONGS_EQUAL(0, metricfs_write(fs, data, sizeof(data), NULL));
+
+	mock().expectOneCall("fake_read")
+		.withParameter("key", "prefix/0")
+		.ignoreOtherParameters()
+		.andReturnValue(-ENOENT);
+	expect_outdex_write("prefix/0", data, sizeof(data));
+	LONGS_EQUAL(-ENOENT, metricfs_read_first(fs, data, sizeof(data), NULL));
+	LONGS_EQUAL(1, metricfs_count(fs));
+}


### PR DESCRIPTION
This pull request introduces a new metric file system implementation for the project. The changes include the addition of a new header file, a corresponding source file, and a test runner makefile. The most important changes are summarized below:

### New Metric File System Implementation:

* **Header File Addition:**
  * [`modules/metrics/include/libmcu/metricfs.h`](diffhunk://#diff-6764097980343b06105da2163e100706aff4e58613f2d26462534d74a4804d49R1-R204): Added a new header file defining the API for the metric file system, including functions for creating, destroying, writing, reading, and iterating over metrics.

* **Source File Addition:**
  * [`modules/metrics/src/metricfs.c`](diffhunk://#diff-958ad51514f7685b10da97bc8cd66c2a0897362c76f6db8eb53d0f6216d2f07bR1-R308): Added a new source file implementing the metric file system functions declared in the header file. This includes internal helper functions for managing metric indices and iterating over stored metrics.

### Test Runner Configuration:

* **Makefile Addition:**
  * [`tests/runners/metrics/metricfs.mk`](diffhunk://#diff-23404d35df68458de6992690c0f45865ccc1f4d8cd62e6da5965abb2e7721217R1-R20): Added a new makefile to configure the test runner for the metric file system, specifying source files, test files, and include directories.