### PR TITLE
fsm: rename fsm_state to fsm_get_state to fix the same name to struct

### DIFF
--- a/modules/fsm/include/libmcu/fsm.h
+++ b/modules/fsm/include/libmcu/fsm.h
@@ -110,7 +110,7 @@ void fsm_reset(struct fsm *fsm);
  *
  * @return The current state of the FSM.
  */
-fsm_state_t fsm_state(const struct fsm *fsm);
+fsm_state_t fsm_get_state(const struct fsm *fsm);
 
 #if defined(__cplusplus)
 }

--- a/modules/fsm/src/fsm.c
+++ b/modules/fsm/src/fsm.c
@@ -57,7 +57,7 @@ fsm_state_t fsm_step(struct fsm *fsm)
 	return fsm->state.present;
 }
 
-fsm_state_t fsm_state(const struct fsm *fsm)
+fsm_state_t fsm_get_state(const struct fsm *fsm)
 {
 	return fsm->state.present;
 }

--- a/tests/src/fsm/fsm_test.cpp
+++ b/tests/src/fsm/fsm_test.cpp
@@ -71,7 +71,7 @@ TEST_GROUP(FSM) {
 };
 
 TEST(FSM, ShouldBeStateA_WhenInitialized) {
-	LONGS_EQUAL(A, fsm_state(&fsm));
+	LONGS_EQUAL(A, fsm_get_state(&fsm));
 }
 
 TEST(FSM, ShouldCheckFirstRegisteredEventFirst) {
@@ -103,7 +103,7 @@ TEST(FSM, ShouldChangeState_WhenEventReturnTrue) {
 	mock().expectOneCall("is_state_b").andReturnValue(true);
 	mock().expectOneCall("do_state_b");
 	LONGS_EQUAL(B, fsm_step(&fsm));
-	LONGS_EQUAL(B, fsm_state(&fsm));
+	LONGS_EQUAL(B, fsm_get_state(&fsm));
 }
 
 TEST(FSM, ShouldIgnoreNullAction_WhenEventReturnTrue) {


### PR DESCRIPTION
This pull request includes several changes to the `fsm_state` function, renaming it to `fsm_get_state` across different files for consistency. The most important changes include modifications to the function declaration, definition, and related test cases.

Function renaming:

* [`modules/fsm/include/libmcu/fsm.h`](diffhunk://#diff-921d067689e0987308aaf2b52ee98e07c9d217f8fd9b3a5d818b077afb0b51cdL113-R113): Renamed `fsm_state` to `fsm_get_state` in the function declaration.
* [`modules/fsm/src/fsm.c`](diffhunk://#diff-d29a53c47d361e7f4d2952555b26998859db1bca461e3298534d03d9b1539cc0L60-R60): Updated the function definition from `fsm_state` to `fsm_get_state`.

Test cases update:

* [`tests/src/fsm/fsm_test.cpp`](diffhunk://#diff-db82371a21afa18b06ba0462ffaa6ecc511343998728f5f84a14159f9451962aL74-R74): Modified test cases to use `fsm_get_state` instead of `fsm_state` in multiple test functions. [[1]](diffhunk://#diff-db82371a21afa18b06ba0462ffaa6ecc511343998728f5f84a14159f9451962aL74-R74) [[2]](diffhunk://#diff-db82371a21afa18b06ba0462ffaa6ecc511343998728f5f84a14159f9451962aL106-R106)