### PR TITLE
common: add ISO8601 time conversion function

### DIFF
--- a/modules/common/include/libmcu/bitops.h
+++ b/modules/common/include/libmcu/bitops.h
@@ -19,7 +19,9 @@ static inline bool is_power2(const unsigned long x)
 	return (x != 0) && ((x & (x - 1)) == 0);
 }
 
+#if !defined(_STRING_H_)
 int flsl(long x);
+#endif
 
 #if defined(__cplusplus)
 }

--- a/modules/common/include/libmcu/ringbuf.h
+++ b/modules/common/include/libmcu/ringbuf.h
@@ -27,7 +27,7 @@ struct ringbuf {
 
 #define DEFINE_RINGBUF(_name, _bufsize) \
 	static uint8_t LIBMCU_CONCAT(_name, _buf)[_bufsize]; \
-	struct ringbuf _name = { \
+	static struct ringbuf _name = { \
 		.capacity = _bufsize, \
 		.index = 0, \
 		.outdex = 0, \

--- a/modules/common/include/libmcu/timext.h
+++ b/modules/common/include/libmcu/timext.h
@@ -12,11 +12,26 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#include <time.h>
 
 void timeout_set(unsigned long *goal, unsigned long msec);
 bool timeout_is_expired(unsigned long goal);
 
 void sleep_ms(unsigned long msec);
+
+/**
+ * @brief Converts an ISO 8601 formatted time string to a time_t value.
+ *
+ * This function parses an ISO 8601 formatted time string and converts it to a
+ * time_t value representing the number of seconds since the Unix epoch
+ * (1970-01-01 00:00:00 UTC).
+ *
+ * @param[in] tstr A pointer to the ISO 8601 formatted time string.
+ *
+ * @return A time_t value representing the parsed time, or (time_t)-1 if the
+ *         parsing fails.
+ */
+time_t iso8601_convert_to_time(const char *tstr);
 
 #if defined(__cplusplus)
 }

--- a/modules/common/src/ringbuf.c
+++ b/modules/common/src/ringbuf.c
@@ -90,7 +90,7 @@ static bool consume_core(struct ringbuf *handle, const size_t consume_size)
 	}
 
 #if __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_ATOMICS__)
-		atomic_thread_fence(memory_order_acquire);
+	atomic_thread_fence(memory_order_acquire);
 #endif
 	handle->outdex += consume_size;
 

--- a/modules/common/src/timext.c
+++ b/modules/common/src/timext.c
@@ -6,6 +6,7 @@
 
 #include "libmcu/timext.h"
 #include <string.h>
+#include <stdint.h>
 
 static void strcpy_iso8601_removing_unsupported(char *buf, size_t bufsize,
 		const char *str)
@@ -28,8 +29,8 @@ static void strcpy_iso8601_removing_unsupported(char *buf, size_t bufsize,
 
 static int get_time_difference_from_timezone(const char *str)
 {
+	const size_t len = strlen(str);
 	char *p, *t;
-	const int len = strlen(str);
 
 	/* find time string */
 	if ((t = strstr(str, "T")) == NULL) {
@@ -40,7 +41,7 @@ static int get_time_difference_from_timezone(const char *str)
 		return 0;
 	}
 
-	const int tzlen = len - (int)((uintptr_t)p - (uintptr_t)str);
+	const size_t tzlen = len - (size_t)((uintptr_t)p - (uintptr_t)str);
 	const int hour = (p[1] - '0') * 10 + (p[2] - '0');
 	int min = 0;
 

--- a/modules/common/src/timext.c
+++ b/modules/common/src/timext.c
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "libmcu/timext.h"
+#include <string.h>
+
+static void strcpy_iso8601_removing_unsupported(char *buf, size_t bufsize,
+		const char *str)
+{
+	char *p, *t;
+
+	strncpy(buf, str, bufsize);
+
+	if ((p = strstr(buf, ".")) == NULL) {
+		return;
+	}
+
+	/* remove milli seconds */
+	if ((t = strstr(p, "+")) != NULL || (t = strstr(p, "-")) != NULL) {
+		for (int i = 0; t[i]; i++) {
+			p[i] = t[i];
+		}
+	}
+}
+
+static int get_time_difference_from_timezone(const char *str)
+{
+	char *p, *t;
+	const int len = strlen(str);
+
+	/* find time string */
+	if ((t = strstr(str, "T")) == NULL) {
+		return 0;
+	}
+
+	if ((p = strstr(t, "+")) == NULL && (p = strstr(t, "-")) == NULL) {
+		return 0;
+	}
+
+	const int tzlen = len - (int)((uintptr_t)p - (uintptr_t)str);
+	const int hour = (p[1] - '0') * 10 + (p[2] - '0');
+	int min = 0;
+
+	if (tzlen > 5 && strstr(p, ":") != NULL) {
+		min = (p[4] - '0') * 10 + (p[5] - '0');
+	} else if (tzlen == 5) {
+		min = (p[3] - '0') * 10 + (p[4] - '0');
+	}
+
+	const int seconds = (hour * 60 + min) * 60 * (p[0] == '-'? 1 : -1);
+
+	return seconds;
+}
+
+time_t iso8601_convert_to_time(const char *tstr)
+{
+	struct tm tim;
+	time_t t = -1; /* time_t never gets negative value. */
+	char tmp[32] = { 0, };
+
+	strcpy_iso8601_removing_unsupported(tmp, sizeof(tmp)-1, tstr);
+
+	if (strptime(tmp, "%Y-%m-%dT%H:%M:%S%z", &tim) != NULL) {
+		t = mktime(&tim);
+	} else if (strptime(tmp, "%Y-%m-%dT%H:%M:%S", &tim) != NULL) {
+		t = mktime(&tim);
+		t += get_time_difference_from_timezone(tmp);
+	}
+
+	return t;
+}

--- a/projects/toolchain.mk
+++ b/projects/toolchain.mk
@@ -79,6 +79,7 @@ endif
 
 ifeq ($(shell uname), Darwin)
 else
+LIBMCU_CFLAGS += -D_GNU_SOURCE -D__USE_XOPEN
 endif
 
 ## Linker options


### PR DESCRIPTION
This pull request includes changes to the `libmcu` module, focusing on enhancements to the `ringbuf` and `timext` components. The most important changes include making the `ringbuf` structure static, adding a new function for ISO 8601 time conversion, and implementing the corresponding logic in `timext.c`.

Enhancements to `ringbuf`:

* [`modules/common/include/libmcu/ringbuf.h`](diffhunk://#diff-196a108f5e69e1e6e537b031bdb00b27b354b82e52d6de709630fb34021a07d5L30-R30): Modified the `DEFINE_RINGBUF` macro to make the `ringbuf` structure static.

Enhancements to `timext`:

* [`modules/common/include/libmcu/timext.h`](diffhunk://#diff-5145b19d2bd293d5524e882f99d1403459ae1ad5ff2f87f25b9f323bd2916917R15-R35): Added a new function `iso8601_convert_to_time` for converting ISO 8601 formatted time strings to `time_t` values.
* [`modules/common/src/timext.c`](diffhunk://#diff-2b2edc4c907cb87a838f19d8bb52686490d057d9b8e7048fac3aac5d1f900b8fR1-R74): Implemented the `iso8601_convert_to_time` function, including helper functions for parsing and handling time differences from time zones.