### PR TITLE
chore/common: conditionally include _GNU_SOURCE for GNU-specific code

### DIFF
--- a/modules/common/include/libmcu/bitops.h
+++ b/modules/common/include/libmcu/bitops.h
@@ -19,9 +19,7 @@ static inline bool is_power2(const unsigned long x)
 	return (x != 0) && ((x & (x - 1)) == 0);
 }
 
-#if !defined(_STRING_H_)
 int flsl(long x);
-#endif
 
 #if defined(__cplusplus)
 }

--- a/modules/common/include/libmcu/timext.h
+++ b/modules/common/include/libmcu/timext.h
@@ -19,6 +19,7 @@ bool timeout_is_expired(unsigned long goal);
 
 void sleep_ms(unsigned long msec);
 
+#if defined(_GNU_SOURCE)
 /**
  * @brief Converts an ISO 8601 formatted time string to a time_t value.
  *
@@ -32,6 +33,7 @@ void sleep_ms(unsigned long msec);
  *         parsing fails.
  */
 time_t iso8601_convert_to_time(const char *tstr);
+#endif
 
 #if defined(__cplusplus)
 }

--- a/modules/common/src/timext.c
+++ b/modules/common/src/timext.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <stdint.h>
 
+#if defined(_GNU_SOURCE)
 static void strcpy_iso8601_removing_unsupported(char *buf, size_t bufsize,
 		const char *str)
 {
@@ -73,3 +74,4 @@ time_t iso8601_convert_to_time(const char *tstr)
 
 	return t;
 }
+#endif

--- a/projects/toolchain.mk
+++ b/projects/toolchain.mk
@@ -79,7 +79,6 @@ endif
 
 ifeq ($(shell uname), Darwin)
 else
-LIBMCU_CFLAGS += -D_GNU_SOURCE -D__USE_XOPEN
 endif
 
 ## Linker options


### PR DESCRIPTION
This pull request includes changes to improve compatibility and conditional compilation across various files. The most important changes include adding conditional compilation guards for GNU source-specific code and removing redundant preprocessor conditionals.

### Improvements to conditional compilation:

* [`modules/common/include/libmcu/timext.h`](diffhunk://#diff-5145b19d2bd293d5524e882f99d1403459ae1ad5ff2f87f25b9f323bd2916917R22): Added conditional compilation guards around the `iso8601_convert_to_time` function to ensure it is only included when `_GNU_SOURCE` is defined. [[1]](diffhunk://#diff-5145b19d2bd293d5524e882f99d1403459ae1ad5ff2f87f25b9f323bd2916917R22) [[2]](diffhunk://#diff-5145b19d2bd293d5524e882f99d1403459ae1ad5ff2f87f25b9f323bd2916917R36)
* [`modules/common/src/timext.c`](diffhunk://#diff-2b2edc4c907cb87a838f19d8bb52686490d057d9b8e7048fac3aac5d1f900b8fR11): Added conditional compilation guards around the `strcpy_iso8601_removing_unsupported` function and the `iso8601_convert_to_time` function to ensure they are only included when `_GNU_SOURCE` is defined. [[1]](diffhunk://#diff-2b2edc4c907cb87a838f19d8bb52686490d057d9b8e7048fac3aac5d1f900b8fR11) [[2]](diffhunk://#diff-2b2edc4c907cb87a838f19d8bb52686490d057d9b8e7048fac3aac5d1f900b8fR77)

### Code cleanup:

* [`modules/common/include/libmcu/bitops.h`](diffhunk://#diff-45a08a1645f21da9c2637afbe246a7d24e899dd2ad28eff3abaf76b797587d8fL22-L24): Removed redundant preprocessor conditionals around the `flsl` function declaration.

### Toolchain configuration:

* [`projects/toolchain.mk`](diffhunk://#diff-b4eb4cc37432beb1594440c9dc56a1d32674b7471e9370b4d8479b2ad5a7a9c1L82): Removed the addition of `_GNU_SOURCE` and `__USE_XOPEN` definitions for non-Darwin systems, simplifying the makefile.