### PR TITLE
chore/test: add board_get_serial_number_string() stubs

### DIFF
--- a/tests/mocks/board.cpp
+++ b/tests/mocks/board.cpp
@@ -20,3 +20,7 @@ uint32_t board_random(void) {
 unsigned long board_get_current_stack_watermark(void) {
 	return mock().actualCall(__func__).returnUnsignedIntValue();
 }
+
+const char *board_get_serial_number_string(void) {
+	return mock().actualCall(__func__).returnStringValue();
+}

--- a/tests/stubs/board.cpp
+++ b/tests/stubs/board.cpp
@@ -20,3 +20,7 @@ uint32_t board_random(void) {
 unsigned long board_get_current_stack_watermark(void) {
 	return 0;
 }
+
+const char *board_get_serial_number_string(void) {
+	return NULL;
+}


### PR DESCRIPTION
This pull request includes changes to the `tests/mocks/board.cpp` and `tests/stubs/board.cpp` files to add a new function `board_get_serial_number_string`.

New function additions:

* [`tests/mocks/board.cpp`](diffhunk://#diff-ad7a39c5ce19b835b2c96270b93d48f09ab3a267c8c8c7f54bbdf892d0a869a4R23-R26): Added the `board_get_serial_number_string` function, which returns a string value from the mock call.
* [`tests/stubs/board.cpp`](diffhunk://#diff-b4af2c9da4052f8fda5e91ee45617b369c79b030559e5c0c45307305e4e63271R23-R26): Added the `board_get_serial_number_string` function, which returns `NULL`.