### PR TITLE
interface/dfu: add function to abort ongoing DFU operation

### DIFF
--- a/modules/dfu/include/libmcu/dfu.h
+++ b/modules/dfu/include/libmcu/dfu.h
@@ -115,6 +115,20 @@ dfu_error_t dfu_write(struct dfu *dfu, uint32_t offset,
 dfu_error_t dfu_finish(struct dfu *dfu);
 
 /**
+ * @brief Aborts the ongoing DFU operation.
+ *
+ * This function aborts the current DFU operation for the given DFU instance.
+ * It stops any ongoing update tasks and cleans up any resources associated with
+ * the update.
+ *
+ * @param[in] dfu Pointer to the DFU instance for which the update is to be
+ *            aborted.
+ *
+ * @return A dfu_error_t indicating the result of the operation.
+ */
+dfu_error_t dfu_abort(struct dfu *dfu);
+
+/**
  * @brief Commits the DFU process, making the update permanent.
  *
  * @param[in,out] dfu A pointer to the DFU instance.


### PR DESCRIPTION
This pull request includes a new function to the DFU (Device Firmware Update) module to handle aborting ongoing DFU operations. The most important change is the addition of the `dfu_abort` function to the `dfu.h` header file.

New functionality:

* [`modules/dfu/include/libmcu/dfu.h`](diffhunk://#diff-2d35b546b67ce98a779eb44d63d6331b3f666b9d8f283007e74e9981e4630912R117-R130): Added the `dfu_abort` function to abort the ongoing DFU operation, stop any ongoing update tasks, and clean up resources associated with the update.