### PR TITLE
test/mock: add dfu mocks

### DIFF
--- a/tests/mocks/dfu.cpp
+++ b/tests/mocks/dfu.cpp
@@ -1,0 +1,54 @@
+#include "CppUTestExt/MockSupport.h"
+#include "libmcu/dfu.h"
+
+struct dfu *dfu_new(size_t data_block_size) {
+	return (struct dfu *)mock().actualCall(__func__)
+		.withParameter("data_block_size", data_block_size)
+		.returnPointerValue();
+}
+
+void dfu_delete(struct dfu *dfu) {
+	mock().actualCall(__func__);
+}
+
+dfu_error_t dfu_prepare(struct dfu *dfu, const struct dfu_image_header *header) {
+	return (dfu_error_t)mock().actualCall(__func__)
+		.withParameter("header", header)
+		.returnIntValue();
+}
+
+dfu_error_t dfu_write(struct dfu *dfu, uint32_t offset,
+		const void *data, size_t datasize) {
+	return (dfu_error_t)mock().actualCall(__func__)
+		.withParameter("offset", offset)
+		.withParameter("data", data)
+		.withParameter("datasize", datasize)
+		.returnIntValue();
+}
+
+dfu_error_t dfu_finish(struct dfu *dfu) {
+	return (dfu_error_t)mock().actualCall(__func__)
+		.returnIntValue();
+}
+
+dfu_error_t dfu_abort(struct dfu *dfu) {
+	return (dfu_error_t)mock().actualCall(__func__)
+		.returnIntValue();
+}
+
+dfu_error_t dfu_commit(struct dfu *dfu) {
+	return (dfu_error_t)mock().actualCall(__func__)
+		.returnIntValue();
+}
+
+bool dfu_is_valid_header(const struct dfu_image_header *header) {
+	return mock().actualCall(__func__)
+		.withParameter("header", header)
+		.returnBoolValue();
+}
+
+dfu_error_t dfu_invalidate(dfu_slot_t slot) {
+	return (dfu_error_t)mock().actualCall(__func__)
+		.withParameter("slot", slot)
+		.returnIntValue();
+}


### PR DESCRIPTION
This pull request introduces a mock implementation for the `dfu` module in the `tests/mocks/dfu.cpp` file. The changes are primarily focused on adding mock functions to simulate the behavior of the `dfu` module for testing purposes.

Mock implementation for `dfu` module:

* Added mock function `dfu_new` to simulate creating a new `dfu` instance with a specified data block size.
* Added mock function `dfu_delete` to simulate deleting a `dfu` instance.
* Added mock function `dfu_prepare` to simulate preparing a `dfu` instance with a given image header.
* Added mock functions `dfu_write`, `dfu_finish`, `dfu_abort`, `dfu_commit`, `dfu_is_valid_header`, and `dfu_invalidate` to simulate various operations on a `dfu` instance, such as writing data, finishing, aborting, committing, validating headers, and invalidating slots.