### PR TITLE
test/stubs: add stubs for metrics

### DIFF
--- a/tests/stubs/metrics.cpp
+++ b/tests/stubs/metrics.cpp
@@ -1,0 +1,72 @@
+#include "CppUTestExt/MockSupport.h"
+#include "libmcu/metrics.h"
+
+void metrics_set(const metric_key_t key, const metric_value_t val) {
+	(void)key;
+	(void)val;
+}
+
+void metrics_set_if_min(const metric_key_t key, const metric_value_t val) {
+	(void)key;
+	(void)val;
+}
+
+void metrics_set_if_max(const metric_key_t key, const metric_value_t val) {
+	(void)key;
+	(void)val;
+}
+
+void metrics_set_max_min(const metric_key_t k_max, const metric_key_t k_min,
+		const metric_value_t val) {
+	(void)k_max;
+	(void)k_min;
+	(void)val;
+}
+
+metric_value_t metrics_get(const metric_key_t key) {
+	(void)key;
+	return 0;
+}
+
+void metrics_increase(const metric_key_t key) {
+	(void)key;
+}
+
+void metrics_increase_by(const metric_key_t key, const metric_value_t n) {
+	(void)key;
+	(void)n;
+}
+
+void metrics_reset(void) {
+}
+
+bool metrics_is_set(const metric_key_t key) {
+	(void)key;
+	return false;
+}
+
+void metrics_iterate(void (*callback_each)(const metric_key_t key,
+				const metric_value_t value, void *ctx),
+		void *ctx) {
+	(void)callback_each;
+	(void)ctx;
+}
+
+size_t metrics_collect(void *buf, const size_t bufsize) {
+	(void)buf;
+	(void)bufsize;
+	return 0;
+}
+
+size_t metrics_count(void) {
+	return 0;
+}
+
+void metrics_init(const bool force) {
+	(void)force;
+}
+
+const char *metrics_stringify_key(const metric_key_t key) {
+	(void)key;
+	return NULL;
+}


### PR DESCRIPTION
This pull request includes the addition of stub functions for the `metrics` module in the `tests/stubs/metrics.cpp` file. These changes provide mock implementations for various metrics-related functions, which will be useful for unit testing purposes.

Stub functions added:

* `metrics_set`, `metrics_set_if_min`, `metrics_set_if_max`, `metrics_set_max_min`: Added to set metric values with different conditions.
* `metrics_get`, `metrics_increase`, `metrics_increase_by`, `metrics_reset`, `metrics_is_set`: Added to retrieve, modify, and reset metric values.
* `metrics_iterate`, `metrics_collect`, `metrics_count`, `metrics_init`, `metrics_stringify_key`: Added to iterate over metrics, collect metrics data, count metrics, initialize metrics, and convert metric keys to strings.