### PR TITLE
common/strext: add strupper and strlower functions

### DIFF
--- a/modules/common/include/libmcu/strext.h
+++ b/modules/common/include/libmcu/strext.h
@@ -21,6 +21,28 @@ extern "C" {
  */
 char *strtrim(char *s, const char c);
 
+/**
+ * @brief Converts all characters in the string to uppercase.
+ *
+ * This function iterates through each character in the input string
+ * and converts it to its uppercase equivalent.
+ *
+ * @param[in,out] s The input string to be converted. The string is modified
+ *                in place.
+ */
+void strupper(char *s);
+
+/**
+ * @brief Converts all characters in the string to lowercase.
+ *
+ * This function iterates through each character in the input string
+ * and converts it to its lowercase equivalent.
+ *
+ * @param[in,out] s The input string to be converted. The string is modified
+ *                in place.
+ */
+void strlower(char *s);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/modules/common/src/strext.c
+++ b/modules/common/src/strext.c
@@ -38,3 +38,23 @@ char *strtrim(char *s, const char c)
 
 	return s;
 }
+
+void strupper(char *s)
+{
+	while (s && *s) {
+		if (*s >= 'a' && *s <= 'z') {
+			*s = *s - 'a' + 'A';
+		}
+		s++;
+	}
+}
+
+void strlower(char *s)
+{
+	while (s && *s) {
+		if (*s >= 'A' && *s <= 'Z') {
+			*s = *s - 'A' + 'a';
+		}
+		s++;
+	}
+}

--- a/tests/src/common/strext_test.cpp
+++ b/tests/src/common/strext_test.cpp
@@ -33,3 +33,15 @@ TEST(STREXT, strtrim_ShouldRemoveLeadingAndTrailingSpaces) {
 	strtrim(s1, ' ');
 	STRCMP_EQUAL("remove leading and trailing spaces", s1);
 }
+
+TEST(STREXT, strupper_ShouldConvertLowercaseToUppercase) {
+	char s1[] = "hello, world!";
+	strupper(s1);
+	STRCMP_EQUAL("HELLO, WORLD!", s1);
+}
+
+TEST(STREXT, strlower_ShouldConvertUppercaseToLowercase) {
+	char s1[] = "HELLO, WORLD!";
+	strlower(s1);
+	STRCMP_EQUAL("hello, world!", s1);
+}


### PR DESCRIPTION
This pull request introduces new string manipulation functions to the `libmcu` library. The changes include the addition of two new functions, `strupper` and `strlower`, which convert strings to uppercase and lowercase, respectively.

New string manipulation functions:

* [`modules/common/include/libmcu/strext.h`](diffhunk://#diff-793ecedf257d0c9fca5f0529d94e90a560742e44105aa8cb27230495f45108d5R24-R45): Added declarations for `strupper` and `strlower` functions, which convert strings to uppercase and lowercase.
* [`modules/common/src/strext.c`](diffhunk://#diff-8d239449783900892ec04914ac09c889ab4b1e095826450b57e3be2b29366d41R41-R60): Implemented the `strupper` and `strlower` functions, which iterate through each character in the input string and convert it to its uppercase or lowercase equivalent.