### PR TITLE
common/strext: add strchunk()

### DIFF
--- a/modules/common/include/libmcu/strext.h
+++ b/modules/common/include/libmcu/strext.h
@@ -11,6 +11,36 @@
 extern "C" {
 #endif
 
+#include <stddef.h>
+
+/**
+ * @typedef strchunk_cb_t
+ * @brief Callback function type for processing each chunk of the string.
+ *
+ * @param[in] chunk Pointer to the chunk of the string.
+ * @param[in] chunk_len Length of the chunk.
+ * @param[in] ctx User-defined context passed to the callback function.
+ */
+typedef void (*strchunk_cb_t)(const char *chunk, size_t chunk_len, void *ctx);
+
+/**
+ * @brief Splits a string by a delimiter and calls a callback function for each
+ * chunk.
+ *
+ * This function takes an input string and splits it into chunks based on the
+ * specified delimiter. For each chunk, the provided callback function is called
+ * with the chunk, its length, and a user-defined context.
+ *
+ * @param[in] str The input string to be split.
+ * @param[in] delimiter The character used to split the string.
+ * @param[in] cb The callback function to be called for each chunk.
+ * @param[in] cb_ctx User-defined context to be passed to the callback function.
+ *
+ * @return The number of chunks processed.
+ */
+size_t strchunk(const char *str, const char delimiter,
+		strchunk_cb_t cb, void *cb_ctx);
+
 /**
  * @brief Removes the given leading and trailing characters.
  *

--- a/modules/common/src/strext.c
+++ b/modules/common/src/strext.c
@@ -8,6 +8,35 @@
 #include <string.h>
 #include <stddef.h>
 
+size_t strchunk(const char *str, const char delimiter,
+		strchunk_cb_t cb, void *cb_ctx)
+{
+	const char *start = str;
+	const char *end = str;
+	size_t count = 0;
+
+	while (*end) {
+		const size_t len = (size_t)(end - start);
+		if (*end == delimiter) {
+			if (cb && len) {
+				(*cb)(start, len, cb_ctx);
+			}
+			start = end + 1;
+			count = len? count + 1 : count;
+		}
+		end++;
+	}
+
+	if (start != end) {
+		if (cb) {
+			(*cb)(start, (size_t)(end - start), cb_ctx);
+		}
+		count++;
+	}
+
+	return count;
+}
+
 char *strtrim(char *s, const char c)
 {
 	const size_t len = strlen(s);


### PR DESCRIPTION
This pull request introduces a new function `strchunk` to the `libmcu` library, which splits a string by a delimiter and processes each chunk using a callback function. Additionally, corresponding tests have been added to ensure the function works as expected.

### New Functionality:

* **New Function and Typedef:**
  * [`modules/common/include/libmcu/strext.h`](diffhunk://#diff-793ecedf257d0c9fca5f0529d94e90a560742e44105aa8cb27230495f45108d5R14-R43): Added `strchunk_cb_t` typedef for the callback function and declared the `strchunk` function.
  * [`modules/common/src/strext.c`](diffhunk://#diff-8d239449783900892ec04914ac09c889ab4b1e095826450b57e3be2b29366d41R11-R37): Implemented the `strchunk` function to split a string by a delimiter and call a callback function for each chunk.

### Testing Enhancements:

* **Test Setup and Mocking:**
  * [`tests/src/common/strext_test.cpp`](diffhunk://#diff-edcd7402fc4cf84cc633d7033e5d3ec0544dc68e2a02f31685cd66eeaba6fd70R9-R24): Included `CppUTestExt/MockSupport.h` and added the `on_strchunk` mock callback function.
* **New Test Cases:**
  * [`tests/src/common/strext_test.cpp`](diffhunk://#diff-edcd7402fc4cf84cc633d7033e5d3ec0544dc68e2a02f31685cd66eeaba6fd70R57-R104): Added tests for `strchunk` to verify it calls the callback function for each chunk, and handles leading and trailing delimiters correctly.