### PR TITLE
port/spi: esp-idf: dynamically allocate temporary buffers

### DIFF
--- a/interfaces/spi/include/libmcu/spi.h
+++ b/interfaces/spi/include/libmcu/spi.h
@@ -118,12 +118,12 @@ int spi_write(struct spi_device *dev, const void *data, size_t data_len);
  *
  * @param[in] dev The SPI device.
  * @param[out] buf The buffer where the read data will be stored.
- * @param[in] bufsize The size of the buffer.
+ * @param[in] rx_len The length of the data to be read.
  *
  * @return 0 if the operation is successful, otherwise returns a non-zero error
  *         code.
  */
-int spi_read(struct spi_device *dev, void *buf, size_t bufsize);
+int spi_read(struct spi_device *dev, void *buf, size_t rx_len);
 
 /**
  * @brief Write and read data from a SPI device.
@@ -135,14 +135,14 @@ int spi_read(struct spi_device *dev, void *buf, size_t bufsize);
  * @param[in] txdata The data to be written.
  * @param[in] txdata_len The length of the data to be written.
  * @param[out] rxbuf The buffer where the read data will be stored.
- * @param[in] rxbuf_len The size of the buffer.
+ * @param[in] rx_len The length of the data to be read.
  *
  * @return 0 if the operation is successful, otherwise returns a non-zero error
  *         code.
  */
 int spi_writeread(struct spi_device *dev,
 		const void *txdata, size_t txdata_len,
-		void *rxbuf, size_t rxbuf_len);
+		void *rxbuf, size_t rx_len);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
This pull request includes changes to the SPI interface and implementation to improve the consistency and functionality of the SPI read and write operations. The most important changes include modifying the parameter names for better clarity and enhancing the `spi_writeread` function to handle memory allocation and data copying.

Improvements to SPI interface:

* [`interfaces/spi/include/libmcu/spi.h`](diffhunk://#diff-2100b036dba47edf75b3e75c46c178673e25f4ba2debdca5278e3f840558e448L121-R126): Renamed `bufsize` to `rx_len` in `spi_read` and `rxbuf_len` to `rx_len` in `spi_writeread` for better clarity. [[1]](diffhunk://#diff-2100b036dba47edf75b3e75c46c178673e25f4ba2debdca5278e3f840558e448L121-R126) [[2]](diffhunk://#diff-2100b036dba47edf75b3e75c46c178673e25f4ba2debdca5278e3f840558e448L138-R145)

Enhancements to SPI implementation:

* [`ports/esp-idf/spi.c`](diffhunk://#diff-d94c5bf030779b5bcca4eb58ee3f1cd6d5f303a27bd8f3bb00c555ad45ada1daL166-R208): Updated `spi_writeread` to allocate memory for the full transaction, copy the transmit data, and handle memory cleanup. This ensures proper data handling during SPI transactions.
* [`ports/esp-idf/spi.c`](diffhunk://#diff-d94c5bf030779b5bcca4eb58ee3f1cd6d5f303a27bd8f3bb00c555ad45ada1daL166-R208): Modified `spi_read` to use `rx_len` instead of `bufsize` for consistency with the interface changes.

Code cleanup:

* [`ports/esp-idf/spi.c`](diffhunk://#diff-d94c5bf030779b5bcca4eb58ee3f1cd6d5f303a27bd8f3bb00c555ad45ada1daL215): Removed commented-out `SPI_DEVICE_HALFDUPLEX` flag in `spi_enable`.