### PR TITLE
feat(cli): add pause functionality to CLI

### DIFF
--- a/modules/cli/include/libmcu/cli.h
+++ b/modules/cli/include/libmcu/cli.h
@@ -39,6 +39,7 @@ struct cli {
 	size_t bufsize;
 
 	void *env;
+	bool pause;
 };
 
 void cli_init(struct cli *cli, struct cli_io const *io,

--- a/modules/cli/src/cli.c
+++ b/modules/cli/src/cli.c
@@ -367,6 +367,9 @@ static cli_cmd_error_t cli_step_core(struct cli *cli)
 
 cli_cmd_error_t cli_step(struct cli *cli)
 {
+	if (cli->pause) {
+		return CLI_CMD_SUCCESS;
+	}
 	return cli_step_core(cli);
 }
 


### PR DESCRIPTION
This pull request includes changes to the `cli` module to introduce a new `pause` feature. The most important changes involve adding a `pause` member to the `cli` struct and modifying the `cli_step` function to check for this new member.

Enhancements to the `cli` module:

* [`modules/cli/include/libmcu/cli.h`](diffhunk://#diff-e592a9504256378e485c949dab7f7b80b0c230c6b769a5dd6702bedcec3f5d4aR42): Added a `pause` boolean member to the `cli` struct.
* [`modules/cli/src/cli.c`](diffhunk://#diff-f9799fa55c35ec47020b5358b252cf5e2ae03a2f68f86b4b92949f80bae6ff42R370-R372): Updated the `cli_step` function to check the `pause` member and return early if it is set to true.