### PR TITLE
dfu: make IV argument optional with default value

### DIFF
--- a/modules/dfu/generate_dfu_header.py
+++ b/modules/dfu/generate_dfu_header.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
     parser.add_argument('--type', required=True, choices=['app', 'loader', 'updator'], help="DFU type")
     parser.add_argument('--output', required=True, help="Output file path")
     parser.add_argument('--vector', type=lambda x: int(x, 0), default=0, help="Vector address (default: 0)")
-    parser.add_argument('--iv', required=True, help="Initialization Vector (IV) as a 32-character hex string")
+    parser.add_argument('--iv', required=False, default='00000000000000000000000000000000', help="Initialization Vector (IV) as a 32-character hex string")
     parser.add_argument('--signature', required=True, help="Signature as a hex string (up to 128 characters)")
 
     args = parser.parse_args()


### PR DESCRIPTION
This pull request includes a small but important change to the `generate_dfu_header` function in the `modules/dfu/generate_dfu_header.py` file. The change modifies the `--iv` argument to be optional and provides a default value.

* [`modules/dfu/generate_dfu_header.py`](diffhunk://#diff-4ee80c17b1b9aea094bf1cba58bc3039f101c3eceb12adda4bc81a1e786cafd4L100-R100): Changed the `--iv` argument to be optional and set its default value to '00000000000000000000000000000000'.