### PR TITLE
runner: add runner change function with bypass option

### DIFF
--- a/modules/runner/include/libmcu/runner.h
+++ b/modules/runner/include/libmcu/runner.h
@@ -71,10 +71,70 @@ int runner_init(const struct runner *runners, size_t nr_runners, void *ctx);
  */
 int runner_register_change_cb(runner_change_cb_t pre_cb, void *pre_ctx,
 		runner_change_cb_t post_cb, void *post_ctx);
+
+/**
+ * @brief Start the specified runner.
+ *
+ * This function starts the runner of the specified type.
+ *
+ * @param[in] runner_type The type of the runner to start.
+ */
 void runner_start(const runner_t runner_type);
+
+/**
+ * @brief Change the runner type with pre/post callbacks and prepare/terminate.
+ *
+ * This function changes the current runner type to the specified new runner
+ * type. It will call the pre-change and post-change callbacks if they are
+ * defined, and it will also call the runner's prepare and terminate functions.
+ *
+ * @param[in] new_runner_type The new runner type to switch to.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
 int runner_change(const runner_t new_runner_type);
+
+/**
+ * @brief Change the runner type without pre/post callbacks and without
+ * prepare/terminate.
+ *
+ * This function changes the current runner type to the specified new runner
+ * type without calling any pre-change or post-change callbacks, and without
+ * calling the runner's prepare or terminate functions.
+ *
+ * @param[in] new_runner_type The new runner type to switch to.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
+int runner_change_bypass(const runner_t new_runner_type);
+
+/**
+ * @brief Get the current runner.
+ *
+ * This function returns a pointer to the current runner.
+ *
+ * @return A pointer to the current runner.
+ */
 const struct runner *runner_current(void);
+
+/**
+ * @brief Get the type of the specified runner.
+ *
+ * This function returns the type of the specified runner.
+ *
+ * @param[in] runner A pointer to the runner.
+ *
+ * @return The type of the specified runner.
+ */
 runner_t runner_type(const struct runner *runner);
+
+/**
+ * @brief Get the type of the current runner.
+ *
+ * This function returns the type of the current runner.
+ *
+ * @return The type of the current runner.
+ */
 runner_t runner_current_type(void);
 
 #if defined(__cplusplus)


### PR DESCRIPTION
This pull request introduces several new functionalities and refactors existing code in the `runner` module. The most important changes include the addition of new runner management functions, refactoring of existing functions to support bypassing callbacks and preparation/termination steps, and the reorganization of function definitions.

### New functionalities:

* [`modules/runner/include/libmcu/runner.h`](diffhunk://#diff-e13b24bf7a7191d6e2bb348f9dccd01bcd23e64ad6428b0c8c2d7cc97ddcfe83R74-R137): Added new functions `runner_start`, `runner_change`, `runner_change_bypass`, `runner_current`, `runner_type`, and `runner_current_type` to manage runner states and types.

### Refactoring:

* [`modules/runner/src/runner.c`](diffhunk://#diff-d96c3d5ec98aa98e69ef9cc3c16731904827356340445f68deb962f5bf6347bcL95-R128): Refactored the `runner_change` function to call a new internal function `change_current` with a `bypass` parameter, allowing for bypassing of callbacks and preparation/termination steps.
* [`modules/runner/src/runner.c`](diffhunk://#diff-d96c3d5ec98aa98e69ef9cc3c16731904827356340445f68deb962f5bf6347bcL62-R62): Moved the definitions of `runner_current`, `runner_type`, and `runner_current_type` to the end of the file for better organization and added the new `runner_change_bypass` function.