### PR TITLE
metricfs: fix outdex increment logic

### DIFF
--- a/modules/metrics/src/metricfs.c
+++ b/modules/metrics/src/metricfs.c
@@ -130,7 +130,6 @@ static bool on_clear_iteration(struct metricfs *fs,
 	(void)ctx;
 
 	if (kvstore_clear(fs->kvstore, keystr) >= 0) {
-		fs->outdex += 1;
 		return true;
 	}
 
@@ -141,6 +140,7 @@ static int iterate(struct metricfs *fs, iterator_fn_t fn,
 		struct iterator_ctx *ctx, const uint16_t max_count)
 {
 	const metricfs_id_t outdex = fs->outdex;
+	int err = 0;
 
 	for (uint16_t i = 0; i < max_count; i++) {
 		const metricfs_id_t id = outdex + i;
@@ -150,11 +150,13 @@ static int iterate(struct metricfs *fs, iterator_fn_t fn,
 		ctx->id = id;
 
 		if (!(*fn)(fs, keystr, ctx)) {
-			return -EIO;
+			err = -EIO;
 		}
+
+		fs->outdex += 1;
 	}
 
-	return 0;
+	return err;
 }
 
 int metricfs_write(struct metricfs *fs,


### PR DESCRIPTION
This pull request includes changes to the `modules/metrics/src/metricfs.c` file to improve error handling and iteration behavior. The most important changes include modifying the `iterate` function to handle errors more gracefully and updating the `on_clear_iteration` function.

Error handling improvements:

* [`modules/metrics/src/metricfs.c`](diffhunk://#diff-958ad51514f7685b10da97bc8cd66c2a0897362c76f6db8eb53d0f6216d2f07bL153-R159): Updated the `iterate` function to use an `err` variable instead of returning immediately on error, allowing the loop to complete before returning the error code.
* [`modules/metrics/src/metricfs.c`](diffhunk://#diff-958ad51514f7685b10da97bc8cd66c2a0897362c76f6db8eb53d0f6216d2f07bL153-R159): Added the `fs->outdex += 1` line inside the loop in the `iterate` function to ensure `outdex` is incremented correctly.

Iteration behavior updates:

* [`modules/metrics/src/metricfs.c`](diffhunk://#diff-958ad51514f7685b10da97bc8cd66c2a0897362c76f6db8eb53d0f6216d2f07bL133): Removed the `fs->outdex += 1` line from the `on_clear_iteration` function to prevent unintended increments.
* [`modules/metrics/src/metricfs.c`](diffhunk://#diff-958ad51514f7685b10da97bc8cd66c2a0897362c76f6db8eb53d0f6216d2f07bR143): Initialized the `err` variable in the `iterate` function to ensure it has a default value.