### PR TITLE
ci: add workflow to check version consistency

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -1,0 +1,49 @@
+name: Check version.h before release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get latest tag
+        id: get_tag
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_ENV
+
+      - name: Extract version from version.h
+        id: get_header_version
+        run: |
+          HEADER_VERSION_MAJOR=$(awk '/#define LIBMCU_VERSION_MAJOR/ {print $3}' modules/common/include/libmcu/version.h)
+          HEADER_VERSION_MINOR=$(awk '/#define LIBMCU_VERSION_MINOR/ {print $3}' modules/common/include/libmcu/version.h)
+          HEADER_VERSION_BUILD=$(awk '/#define LIBMCU_VERSION_BUILD/ {print $3}' modules/common/include/libmcu/version.h)
+
+          HEADER_VERSION="$HEADER_VERSION_MAJOR.$HEADER_VERSION_MINOR.$HEADER_VERSION_BUILD"
+
+          echo "Extracted header version: $HEADER_VERSION"
+          echo "HEADER_VERSION=$HEADER_VERSION" >> $GITHUB_ENV
+
+      - name: Compare versions
+        run: |
+          if [ "$TAG_VERSION" != "$HEADER_VERSION" ]; then
+            echo "::error:: version.h numeric version ($HEADER_VERSION) does not match git tag ($TAG_VERSION)"
+            exit 1
+          fi
+          echo "✅ Version match! Proceeding with release."
+
+      - name: Trigger Release Workflow
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: release-approved
+          client-payload: '{"tag": "${{ env.TAG_VERSION }}"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,40 +1,41 @@
 name: release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  repository_dispatch:
+    types: [release-approved]
 
 jobs:
   build:
     name: Create Release
     runs-on: ubuntu-latest
     container: libmcu/ci:latest
+
     steps:
       - name: Clone Repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
-      - name: Build Project
-        run: CROSS_COMPILE=arm-none-eabi VERSION=${GITHUB_REF#refs/tags/} make
+
       - name: Get Version
         id: get_version
         run: |
-          echo ::set-output name=HASH::$(cat build/libmcu_*.sha256)
-          echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body: |
-            ${{ steps.get_version.outputs.HASH }}
+          TAG_VERSION="${{ github.event.client_payload.tag }}"
+          echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_ENV
 
-            ## Features
-            ## Bug Fixes
-          draft: true
-          prerelease: false
+      - name: Build Project
+        run: CROSS_COMPILE=arm-none-eabi VERSION=${{ env.TAG_VERSION }} make
+
+      - name: Calculate Hash
+        id: hash
+        run: |
+          HASH=$(cat build/libmcu_*.sha256)
+          echo "HASH=$HASH" >> $GITHUB_ENV
+
+      - name: Create GitHub Release
+        run: |
+          gh release create v${{ env.TAG_VERSION }} \
+            --title "v${{ env.TAG_VERSION }}" \
+            --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/modules/common/include/libmcu/version.h
+++ b/modules/common/include/libmcu/version.h
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: 2025 권경환 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef LIBMCU_VERSION_H
+#define LIBMCU_VERSION_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#if !defined(MAKE_VERSION)
+#define MAKE_VERSION(major, minor, patch)	\
+	(((major) << 16) | ((minor) << 8) | (patch))
+#endif
+
+#define LIBMCU_VERSION_MAJOR	0
+#define LIBMCU_VERSION_MINOR	2
+#define LIBMCU_VERSION_BUILD	6
+#define LIBMCU_VERSION		MAKE_VERSION(LIBMCU_VERSION_MAJOR, \
+					LIBMCU_VERSION_MINOR, \
+					LIBMCU_VERSION_BUILD)
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* LIBMCU_VERSION_H */


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to verify the version number in `version.h` before releasing and adds a version header file to the project. The most important changes include the addition of the workflow file and the creation of the version header file.

### New GitHub Actions Workflow:

* [`.github/workflows/check-version.yml`](diffhunk://#diff-8afe568f7bca31f3457ff9b8e7fc829ac3918722cb3c77aa85b59c197b113664R1-R47): Added a workflow to check the version number in `version.h` before releasing. This workflow includes steps to checkout the repository, get the latest tag, extract the version from `version.h`, compare the versions, and proceed with the release if they match.

### Version Header File:

* [`modules/common/include/libmcu/version.h`](diffhunk://#diff-c6d23c72f8755cdea3fba3881c06e5965825eeddea4cc59f3536b5671ec4111aR1-R30): Created a new version header file defining the version macros `LIBMCU_VERSION_MAJOR`, `LIBMCU_VERSION_MINOR`, `LIBMCU_VERSION_BUILD`, and `LIBMCU_VERSION`. This file also includes a macro `MAKE_VERSION` to combine the version components.