### PR TITLE
fix: resolve type casting and struct initialization issues

### DIFF
--- a/modules/common/src/timext.c
+++ b/modules/common/src/timext.c
@@ -42,7 +42,7 @@ static int get_time_difference_from_timezone(const char *str)
 		return 0;
 	}
 
-	const size_t tzlen = len - (size_t)((uintptr_t)p - (uintptr_t)str);
+	const size_t tzlen = len - ((uintptr_t)p - (uintptr_t)str);
 	const int hour = (p[1] - '0') * 10 + (p[2] - '0');
 	int min = 0;
 

--- a/modules/common/src/xmodem.c
+++ b/modules/common/src/xmodem.c
@@ -220,7 +220,7 @@ static xmodem_error_t check_buffer(const struct packet *packet, size_t index)
 			return XMODEM_ERROR_RETRY;
 		}
 	} else if (index == 2) {
-		if ((uint8_t)~packet->seq != (uint8_t)packet->seq_inverted) {
+		if ((uint8_t)~packet->seq != packet->seq_inverted) {
 			return XMODEM_ERROR_RETRY;
 		}
 	}
@@ -231,7 +231,7 @@ static xmodem_error_t read_packet(struct packet *packet,
 		size_t data_size, bool use_crc, uint32_t timeout_ms)
 {
 	const uint32_t t_started = millis();
-	size_t *index = (size_t *)&packet->received;
+	size_t *index = &packet->received;
 	xmodem_error_t err = XMODEM_ERROR_TIMEOUT;
 	uint32_t t_read = t_started;
 	uint32_t t_now;

--- a/modules/fsm/include/libmcu/fsm.h
+++ b/modules/fsm/include/libmcu/fsm.h
@@ -16,9 +16,9 @@ extern "C" {
 #include <stdint.h>
 
 #define FSM_ITEM(present_state, event_func, action_func, next_state) { \
-		.state = (struct fsm_state) { present_state, next_state }, \
+		.state = { .present = present_state, .next = next_state }, \
 		.event = event_func, \
-		.action = action_func, \
+		.action = { .run = action_func }, \
 	}
 
 typedef int16_t fsm_state_t;


### PR DESCRIPTION
This pull request includes several changes to improve code readability and maintainability in the `modules/common/src` and `modules/fsm/include` directories. The most important changes involve simplifying type casts, improving type safety, and enhancing the readability of macro definitions.

### Code readability and maintainability improvements:

* [`modules/common/src/timext.c`](diffhunk://#diff-2b2edc4c907cb87a838f19d8bb52686490d057d9b8e7048fac3aac5d1f900b8fL45-R45): Simplified the calculation of `tzlen` by removing an unnecessary type cast.
* [`modules/common/src/xmodem.c`](diffhunk://#diff-ec57f5264a97e07e026f332f86159f0a33c3f342cbaa937130419bca4f8a2154L223-R223): Improved type safety in `check_buffer` by removing an unnecessary cast in the comparison of `packet->seq` and `packet->seq_inverted`.
* [`modules/common/src/xmodem.c`](diffhunk://#diff-ec57f5264a97e07e026f332f86159f0a33c3f342cbaa937130419bca4f8a2154L234-R234): Simplified the initialization of the `index` variable in `read_packet` by removing an unnecessary cast.
* [`modules/fsm/include/libmcu/fsm.h`](diffhunk://#diff-921d067689e0987308aaf2b52ee98e07c9d217f8fd9b3a5d818b077afb0b51cdL19-R21): Enhanced the readability of the `FSM_ITEM` macro by using designated initializers for struct members.