### PR TITLE
fix(ci): handle missing tags gracefully in TAG_VERSION

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -21,10 +21,14 @@ jobs:
       - name: Get latest tag or PR base branch
         id: get_tag
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            TAG_VERSION=$(git describe --tags --abbrev=0 | sed 's/^v//')
-          else
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          else
+            TAG_VERSION=$(git describe --tags --abbrev=0 | sed 's/^v//')
+            if [[ -z "$TAG_VERSION" ]]; then
+              echo "No valid tags found. Setting TAG_VERSION to 'unknown'."
+              TAG_VERSION="unknown"
+            fi
           fi
           echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_ENV
 


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/check-version.yml` file, specifically in the `jobs:` section. The change improves the logic for determining the `TAG_VERSION` during GitHub Actions.

Improvements to `TAG_VERSION` determination:

* [`.github/workflows/check-version.yml`](diffhunk://#diff-8afe568f7bca31f3457ff9b8e7fc829ac3918722cb3c77aa85b59c197b113664L24-R31): Modified the script to handle cases where no valid tags are found by setting `TAG_VERSION` to 'unknown' if necessary.