### PR TITLE
refactor: apply prefix to all public interface symbols

### DIFF
--- a/examples/memory_kvstore.c
+++ b/examples/memory_kvstore.c
@@ -121,6 +121,12 @@ static int memory_kvstore_read(struct kvstore *kvstore,
 	return 0;
 }
 
+static int memory_kvstore_open(struct kvstore *kvstore, const char *ns)
+{
+	(void)kvstore;
+	return 0;
+}
+
 void memory_kvstore_destroy(struct kvstore *kvstore)
 {
 	struct list *p, *n;
@@ -158,6 +164,7 @@ struct kvstore *memory_kvstore_create(char const *ns)
 
 	p->api.write = memory_kvstore_write;
 	p->api.read = memory_kvstore_read;
+	p->api.open = memory_kvstore_open;
 	list_init(&p->keylist_head);
 	strcpy(p->namespace, ns);
 	p->namespace[len] = '\0';

--- a/interfaces/adc/include/libmcu/adc.h
+++ b/interfaces/adc/include/libmcu/adc.h
@@ -13,78 +13,73 @@ extern "C" {
 
 #include <stdint.h>
 
-#define adc_enable		libmcu_adc_enable
-#define adc_disable		libmcu_adc_disable
-#define adc_channel_init	libmcu_adc_channel_init
-#define adc_calibrate		libmcu_adc_calibrate
-#define adc_channel_t		libmcu_adc_channel_t
-
 typedef enum {
-	ADC_CH_1		= 0x00000001UL,
-	ADC_CH_2		= 0x00000002UL,
-	ADC_CH_3		= 0x00000004UL,
-	ADC_CH_4		= 0x00000008UL,
-	ADC_CH_5		= 0x00000010UL,
-	ADC_CH_6		= 0x00000020UL,
-	ADC_CH_7		= 0x00000040UL,
-	ADC_CH_8		= 0x00000080UL,
-	ADC_CH_9		= 0x00000100UL,
-	ADC_CH_10		= 0x00000200UL,
-	ADC_CH_11		= 0x00000400UL,
-	ADC_CH_12		= 0x00000800UL,
-	ADC_CH_13		= 0x00001000UL,
-	ADC_CH_14		= 0x00002000UL,
-	ADC_CH_15		= 0x00004000UL,
-	ADC_CH_16		= 0x00008000UL,
-	ADC_CH_17		= 0x00010000UL,
-	ADC_CH_18		= 0x00020000UL,
-	ADC_CH_19		= 0x00040000UL,
-	ADC_CH_20		= 0x00080000UL,
-	ADC_CH_ALL		= 0x7fffffffUL,
-} adc_channel_t;
+	LM_ADC_CH_1		= 0x00000001UL,
+	LM_ADC_CH_2		= 0x00000002UL,
+	LM_ADC_CH_3		= 0x00000004UL,
+	LM_ADC_CH_4		= 0x00000008UL,
+	LM_ADC_CH_5		= 0x00000010UL,
+	LM_ADC_CH_6		= 0x00000020UL,
+	LM_ADC_CH_7		= 0x00000040UL,
+	LM_ADC_CH_8		= 0x00000080UL,
+	LM_ADC_CH_9		= 0x00000100UL,
+	LM_ADC_CH_10		= 0x00000200UL,
+	LM_ADC_CH_11		= 0x00000400UL,
+	LM_ADC_CH_12		= 0x00000800UL,
+	LM_ADC_CH_13		= 0x00001000UL,
+	LM_ADC_CH_14		= 0x00002000UL,
+	LM_ADC_CH_15		= 0x00004000UL,
+	LM_ADC_CH_16		= 0x00008000UL,
+	LM_ADC_CH_17		= 0x00010000UL,
+	LM_ADC_CH_18		= 0x00020000UL,
+	LM_ADC_CH_19		= 0x00040000UL,
+	LM_ADC_CH_20		= 0x00080000UL,
+	LM_ADC_CH_ALL		= 0x7fffffffUL,
+} lm_adc_channel_t;
 
-struct adc;
+struct lm_adc;
 
-struct adc_api {
-	int (*enable)(struct adc *self);
-	int (*disable)(struct adc *self);
-	int (*init_channel)(struct adc *self, adc_channel_t channel);
-	int (*calibrate)(struct adc *self);
-	int (*measure)(struct adc *self);
-	int (*read)(struct adc *self, adc_channel_t channel);
-	int (*convert_to_millivolts)(struct adc *self, int value);
+struct lm_adc_api {
+	int (*enable)(struct lm_adc *self);
+	int (*disable)(struct lm_adc *self);
+	int (*init_channel)(struct lm_adc *self, lm_adc_channel_t channel);
+	int (*calibrate)(struct lm_adc *self);
+	int (*measure)(struct lm_adc *self);
+	int (*read)(struct lm_adc *self, lm_adc_channel_t channel);
+	int (*convert_to_millivolts)(struct lm_adc *self, int value);
 };
 
-static inline int adc_enable(struct adc *self) {
-	return ((struct adc_api *)self)->enable(self);
+static inline int lm_adc_enable(struct lm_adc *self) {
+	return ((struct lm_adc_api *)self)->enable(self);
 }
 
-static inline int adc_disable(struct adc *self) {
-	return ((struct adc_api *)self)->disable(self);
+static inline int lm_adc_disable(struct lm_adc *self) {
+	return ((struct lm_adc_api *)self)->disable(self);
 }
 
-static inline int adc_channel_init(struct adc *self, adc_channel_t channel) {
-	return ((struct adc_api *)self)->init_channel(self, channel);
+static inline int lm_adc_channel_init(struct lm_adc *self,
+		lm_adc_channel_t channel) {
+	return ((struct lm_adc_api *)self)->init_channel(self, channel);
 }
 
-static inline int adc_calibrate(struct adc *self) {
-	return ((struct adc_api *)self)->calibrate(self);
+static inline int lm_adc_calibrate(struct lm_adc *self) {
+	return ((struct lm_adc_api *)self)->calibrate(self);
 }
 
-static inline int adc_measure(struct adc *self) {
-	return ((struct adc_api *)self)->measure(self);
+static inline int lm_adc_measure(struct lm_adc *self) {
+	return ((struct lm_adc_api *)self)->measure(self);
 }
 
-static inline int adc_read(struct adc *self, adc_channel_t channel) {
-	return ((struct adc_api *)self)->read(self, channel);
+static inline int lm_adc_read(struct lm_adc *self, lm_adc_channel_t channel) {
+	return ((struct lm_adc_api *)self)->read(self, channel);
 }
 
-static inline int adc_convert_to_millivolts(struct adc *self, int value) {
-	return ((struct adc_api *)self)->convert_to_millivolts(self, value);
+static inline int lm_adc_convert_to_millivolts(struct lm_adc *self, int value) {
+	return ((struct lm_adc_api *)self)->convert_to_millivolts(self, value);
 }
 
-struct adc *adc_create(uint8_t adc_num);
-int adc_delete(struct adc *self);
+struct lm_adc *lm_adc_create(uint8_t adc_num);
+int lm_adc_delete(struct lm_adc *self);
 
 #if defined(__cplusplus)
 }

--- a/interfaces/gpio/include/libmcu/gpio.h
+++ b/interfaces/gpio/include/libmcu/gpio.h
@@ -14,52 +14,52 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 
-struct gpio;
+struct lm_gpio;
 
-typedef void (*gpio_callback_t)(struct gpio *gpio, void *ctx);
+typedef void (*lm_gpio_callback_t)(struct lm_gpio *gpio, void *ctx);
 
-struct gpio_api {
-	int (*enable)(struct gpio *self);
-	int (*disable)(struct gpio *self);
-	int (*enable_interrupt)(struct gpio *self);
-	int (*disable_interrupt)(struct gpio *self);
-	int (*set)(struct gpio *self, int value);
-	int (*get)(struct gpio *self);
-	int (*register_callback)(struct gpio *self,
-			gpio_callback_t cb, void *cb_ctx);
+struct lm_gpio_api {
+	int (*enable)(struct lm_gpio *self);
+	int (*disable)(struct lm_gpio *self);
+	int (*enable_interrupt)(struct lm_gpio *self);
+	int (*disable_interrupt)(struct lm_gpio *self);
+	int (*set)(struct lm_gpio *self, int value);
+	int (*get)(struct lm_gpio *self);
+	int (*register_callback)(struct lm_gpio *self,
+			lm_gpio_callback_t cb, void *cb_ctx);
 };
 
-static inline int gpio_enable(struct gpio *self) {
-	return ((struct gpio_api *)self)->enable(self);
+static inline int lm_gpio_enable(struct lm_gpio *self) {
+	return ((struct lm_gpio_api *)self)->enable(self);
 }
 
-static inline int gpio_disable(struct gpio *self) {
-	return ((struct gpio_api *)self)->disable(self);
+static inline int lm_gpio_disable(struct lm_gpio *self) {
+	return ((struct lm_gpio_api *)self)->disable(self);
 }
 
-static inline int gpio_enable_interrupt(struct gpio *self) {
-	return ((struct gpio_api *)self)->enable_interrupt(self);
+static inline int lm_gpio_enable_interrupt(struct lm_gpio *self) {
+	return ((struct lm_gpio_api *)self)->enable_interrupt(self);
 }
 
-static inline int gpio_disable_interrupt(struct gpio *self) {
-	return ((struct gpio_api *)self)->disable_interrupt(self);
+static inline int lm_gpio_disable_interrupt(struct lm_gpio *self) {
+	return ((struct lm_gpio_api *)self)->disable_interrupt(self);
 }
 
-static inline int gpio_set(struct gpio *self, int value) {
-	return ((struct gpio_api *)self)->set(self, value);
+static inline int lm_gpio_set(struct lm_gpio *self, int value) {
+	return ((struct lm_gpio_api *)self)->set(self, value);
 }
 
-static inline int gpio_get(struct gpio *self) {
-	return ((struct gpio_api *)self)->get(self);
+static inline int lm_gpio_get(struct lm_gpio *self) {
+	return ((struct lm_gpio_api *)self)->get(self);
 }
 
-static inline int gpio_register_callback(struct gpio *self,
-		gpio_callback_t cb, void *cb_ctx) {
-	return ((struct gpio_api *)self)->register_callback(self, cb, cb_ctx);
+static inline int lm_gpio_register_callback(struct lm_gpio *self,
+		lm_gpio_callback_t cb, void *cb_ctx) {
+	return ((struct lm_gpio_api *)self)->register_callback(self, cb, cb_ctx);
 }
 
-struct gpio *gpio_create(uint16_t pin);
-void gpio_delete(struct gpio *self);
+struct lm_gpio *lm_gpio_create(uint16_t pin);
+void lm_gpio_delete(struct lm_gpio *self);
 
 #if defined(__cplusplus)
 }

--- a/interfaces/i2c/include/libmcu/i2c.h
+++ b/interfaces/i2c/include/libmcu/i2c.h
@@ -15,87 +15,87 @@ extern "C" {
 #include <stdint.h>
 #include <stdbool.h>
 
-struct i2c;
-struct i2c_device;
+struct lm_i2c;
+struct lm_i2c_device;
 
-struct i2c_bus_api {
-	int (*enable)(struct i2c *bus);
-	int (*disable)(struct i2c *bus);
-	int (*reset)(struct i2c *bus);
-	struct i2c_device *(*create_device)(struct i2c *bus,
+struct lm_i2c_bus_api {
+	int (*enable)(struct lm_i2c *bus);
+	int (*disable)(struct lm_i2c *bus);
+	int (*reset)(struct lm_i2c *bus);
+	struct lm_i2c_device *(*create_device)(struct lm_i2c *bus,
 			uint8_t slave_addr, uint32_t freq_hz);
 };
 
-struct i2c_device_api {
-	void (*delete_device)(struct i2c_device *dev);
+struct lm_i2c_device_api {
+	void (*delete_device)(struct lm_i2c_device *dev);
 
-	int (*read)(struct i2c_device *dev,
+	int (*read)(struct lm_i2c_device *dev,
 			void *buf, size_t bufsize, uint32_t timeout_ms);
-	int (*write)(struct i2c_device *dev,
+	int (*write)(struct lm_i2c_device *dev,
 			const void *data, size_t data_len, uint32_t timeout_ms);
-	int (*read_reg)(struct i2c_device *dev,
+	int (*read_reg)(struct lm_i2c_device *dev,
 			uint32_t reg_addr, uint8_t reg_addr_bits,
 			void *buf, size_t bufsize, uint32_t timeout_ms);
-	int (*write_reg)(struct i2c_device *dev,
+	int (*write_reg)(struct lm_i2c_device *dev,
 			uint32_t reg_addr, uint8_t reg_addr_bits,
 			const void *data, size_t data_len, uint32_t timeout_ms);
 };
 
-struct i2c_pin {
+struct lm_i2c_pin {
 	int sda;
 	int scl;
 };
 
-static inline int i2c_enable(struct i2c *bus) {
-	return ((struct i2c_bus_api *)bus)->enable(bus);
+static inline int lm_i2c_enable(struct lm_i2c *bus) {
+	return ((struct lm_i2c_bus_api *)bus)->enable(bus);
 }
 
-static inline int i2c_disable(struct i2c *bus) {
-	return ((struct i2c_bus_api *)bus)->disable(bus);
+static inline int lm_i2c_disable(struct lm_i2c *bus) {
+	return ((struct lm_i2c_bus_api *)bus)->disable(bus);
 }
 
-static inline int i2c_reset(struct i2c *bus) {
-	return ((struct i2c_bus_api *)bus)->reset(bus);
+static inline int lm_i2c_reset(struct lm_i2c *bus) {
+	return ((struct lm_i2c_bus_api *)bus)->reset(bus);
 }
 
-static inline int i2c_read(struct i2c_device *dev,
+static inline int lm_i2c_read(struct lm_i2c_device *dev,
 		void *buf, size_t bufsize, uint32_t timeout_ms) {
-	return ((struct i2c_device_api *)dev)->read(dev,
+	return ((struct lm_i2c_device_api *)dev)->read(dev,
 			buf, bufsize, timeout_ms);
 }
 
-static inline int i2c_write(struct i2c_device *dev,
+static inline int lm_i2c_write(struct lm_i2c_device *dev,
 		const void *data, size_t data_len, uint32_t timeout_ms) {
-	return ((struct i2c_device_api *)dev)->write(dev,
+	return ((struct lm_i2c_device_api *)dev)->write(dev,
 			data, data_len, timeout_ms);
 }
 
-static inline int i2c_read_reg(struct i2c_device *dev,
+static inline int lm_i2c_read_reg(struct lm_i2c_device *dev,
 		uint32_t reg_addr, uint8_t reg_addr_bits,
 		void *buf, size_t bufsize, uint32_t timeout_ms) {
-	return ((struct i2c_device_api *)dev)->read_reg(dev, reg_addr,
+	return ((struct lm_i2c_device_api *)dev)->read_reg(dev, reg_addr,
 			reg_addr_bits, buf, bufsize, timeout_ms);
 }
 
-static inline int i2c_write_reg(struct i2c_device *dev,
+static inline int lm_i2c_write_reg(struct lm_i2c_device *dev,
 		uint32_t reg_addr, uint8_t reg_addr_bits,
 		const void *data, size_t data_len, uint32_t timeout_ms) {
-	return ((struct i2c_device_api *)dev)->write_reg(dev, reg_addr,
+	return ((struct lm_i2c_device_api *)dev)->write_reg(dev, reg_addr,
 			reg_addr_bits, data, data_len, timeout_ms);
 }
 
-static inline struct i2c_device *i2c_create_device(struct i2c *bus,
+static inline struct lm_i2c_device *lm_i2c_create_device(struct lm_i2c *bus,
 		uint8_t slave_addr, uint32_t freq_hz) {
-	return ((struct i2c_bus_api *)bus)->create_device(bus,
+	return ((struct lm_i2c_bus_api *)bus)->create_device(bus,
 			slave_addr, freq_hz);
 }
 
-static inline void i2c_delete_device(struct i2c_device *dev) {
-	((struct i2c_device_api *)dev)->delete_device(dev);
+static inline void lm_i2c_delete_device(struct lm_i2c_device *dev) {
+	((struct lm_i2c_device_api *)dev)->delete_device(dev);
 }
 
-struct i2c *i2c_create(uint8_t channel, const struct i2c_pin *pin);
-void i2c_delete(struct i2c *bus);
+struct lm_i2c *lm_i2c_create(uint8_t channel, const struct lm_i2c_pin *pin);
+void lm_i2c_delete(struct lm_i2c *bus);
 
 #if defined(__cplusplus)
 }

--- a/interfaces/pwm/include/libmcu/pwm.h
+++ b/interfaces/pwm/include/libmcu/pwm.h
@@ -14,11 +14,11 @@ extern "C" {
 #include <stdint.h>
 #include <stdbool.h>
 
-#define PWM_PCT_TO_MILLI(pct)		((pct) * 1000)
-#define PWM_MILLI_TO_PCT(millipct)	((millipct) / 1000)
+#define LM_PWM_PCT_TO_MILLI(pct)	((pct) * 1000)
+#define LM_PWM_MILLI_TO_PCT(millipct)	((millipct) / 1000)
 
-struct pwm;
-struct pwm_channel;
+struct lm_pwm;
+struct lm_pwm_channel;
 
 /**
  * @brief Create a PWM instance.
@@ -30,7 +30,7 @@ struct pwm_channel;
  * @return A pointer to the created PWM instance. If the creation fails,
  *         the function returns NULL.
  */
-struct pwm *pwm_create(uint8_t timer);
+struct lm_pwm *lm_pwm_create(uint8_t timer);
 
 /**
  * @brief Delete a PWM instance.
@@ -41,7 +41,7 @@ struct pwm *pwm_create(uint8_t timer);
  *
  * @return 0 if the deletion is successful, otherwise returns a non-zero error code.
  */
-int pwm_delete(struct pwm *self);
+int lm_pwm_delete(struct lm_pwm *self);
 
 /**
  * Creates a new PWM channel.
@@ -52,7 +52,8 @@ int pwm_delete(struct pwm *self);
  *
  * @return A pointer to the created PWM channel.
  */
-struct pwm_channel *pwm_create_channel(struct pwm *self, int ch, int pin);
+struct lm_pwm_channel *lm_pwm_create_channel(struct lm_pwm *self,
+		int ch, int pin);
 
 /**
  * Deletes a PWM channel.
@@ -61,7 +62,7 @@ struct pwm_channel *pwm_create_channel(struct pwm *self, int ch, int pin);
  *
  * @return 0 on success, or a negative error code on failure.
  */
-int pwm_delete_channel(struct pwm_channel *ch);
+int lm_pwm_delete_channel(struct lm_pwm_channel *ch);
 
 /**
  * Enables a PWM channel.
@@ -70,7 +71,7 @@ int pwm_delete_channel(struct pwm_channel *ch);
  *
  * @return 0 on success, or a negative error code on failure.
  */
-int pwm_enable(struct pwm_channel *ch);
+int lm_pwm_enable(struct lm_pwm_channel *ch);
 
 /**
  * Disables a PWM channel.
@@ -79,7 +80,7 @@ int pwm_enable(struct pwm_channel *ch);
  *
  * @return 0 on success, or a negative error code on failure.
  */
-int pwm_disable(struct pwm_channel *ch);
+int lm_pwm_disable(struct lm_pwm_channel *ch);
 
 /**
  * @brief Start a PWM channel.
@@ -92,7 +93,8 @@ int pwm_disable(struct pwm_channel *ch);
  *
  * @return 0 if the operation is successful, otherwise returns a non-zero error code.
  */
-int pwm_start(struct pwm_channel *ch, uint32_t freq_hz, uint32_t duty_millipercent);
+int lm_pwm_start(struct lm_pwm_channel *ch,
+		uint32_t freq_hz, uint32_t duty_millipercent);
 
 /**
  * @brief Stop a PWM channel.
@@ -103,7 +105,7 @@ int pwm_start(struct pwm_channel *ch, uint32_t freq_hz, uint32_t duty_milliperce
  *
  * @return 0 if the operation is successful, otherwise returns a non-zero error code.
  */
-int pwm_stop(struct pwm_channel *ch);
+int lm_pwm_stop(struct lm_pwm_channel *ch);
 
 /**
  * @brief Update the frequency of a PWM channel.
@@ -115,7 +117,7 @@ int pwm_stop(struct pwm_channel *ch);
  *
  * @return 0 if the operation is successful, otherwise returns a non-zero error code.
  */
-int pwm_update_frequency(struct pwm_channel *ch, uint32_t hz);
+int lm_pwm_update_frequency(struct lm_pwm_channel *ch, uint32_t hz);
 
 /**
  * @brief Update the duty cycle of a PWM channel.
@@ -127,7 +129,7 @@ int pwm_update_frequency(struct pwm_channel *ch, uint32_t hz);
  *
  * @return 0 if the operation is successful, otherwise returns a non-zero error code.
  */
-int pwm_update_duty(struct pwm_channel *ch, uint32_t millipercent);
+int lm_pwm_update_duty(struct lm_pwm_channel *ch, uint32_t millipercent);
 
 #if defined(__cplusplus)
 }

--- a/interfaces/spi/include/libmcu/spi.h
+++ b/interfaces/spi/include/libmcu/spi.h
@@ -14,25 +14,25 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 
-#if !defined(SPI_PIN_UNASSIGNED)
-#define SPI_PIN_UNASSIGNED		-1
+#if !defined(LM_SPI_PIN_UNASSIGNED)
+#define LM_SPI_PIN_UNASSIGNED		-1
 #endif
 
 typedef enum {
-	SPI_MODE_0, /* CPOL=0, CPHA=0 */
-	SPI_MODE_1, /* CPOL=0, CPHA=1 */
-	SPI_MODE_2, /* CPOL=1, CPHA=0 */
-	SPI_MODE_3, /* CPOL=1, CPHA=1 */
-} spi_mode_t;
+	LM_SPI_MODE_0, /* CPOL=0, CPHA=0 */
+	LM_SPI_MODE_1, /* CPOL=0, CPHA=1 */
+	LM_SPI_MODE_2, /* CPOL=1, CPHA=0 */
+	LM_SPI_MODE_3, /* CPOL=1, CPHA=1 */
+} lm_spi_mode_t;
 
-struct spi_pin {
+struct lm_spi_pin {
 	int miso;
 	int mosi;
 	int sclk;
 };
 
-struct spi;
-struct spi_device;
+struct lm_spi;
+struct lm_spi_device;
 
 /**
  * @brief Create a SPI instance.
@@ -46,7 +46,7 @@ struct spi_device;
  * @return A pointer to the created SPI instance. If the creation fails,
  *         the function returns NULL.
  */
-struct spi *spi_create(uint8_t channel, const struct spi_pin *pin);
+struct lm_spi *lm_spi_create(uint8_t channel, const struct lm_spi_pin *pin);
 
 /**
  * @brief Delete a SPI instance.
@@ -55,7 +55,7 @@ struct spi *spi_create(uint8_t channel, const struct spi_pin *pin);
  *
  * @param[in] self The SPI instance to be deleted.
  */
-void spi_delete(struct spi *self);
+void lm_spi_destroy(struct lm_spi *self);
 
 /**
  * Creates a new SPI device.
@@ -67,8 +67,8 @@ void spi_delete(struct spi *self);
  *
  * @return A pointer to the created SPI device.
  */
-struct spi_device *spi_create_device(struct spi *self,
-		spi_mode_t mode, uint32_t freq_hz, int pin_cs);
+struct lm_spi_device *lm_spi_create_device(struct lm_spi *self,
+		lm_spi_mode_t mode, uint32_t freq_hz, int pin_cs);
 
 /**
  * Deletes an SPI device.
@@ -77,7 +77,7 @@ struct spi_device *spi_create_device(struct spi *self,
  *
  * @return 0 on success, or a negative error code on failure.
  */
-int spi_delete_device(struct spi_device *dev);
+int lm_spi_delete_device(struct lm_spi_device *dev);
 
 /**
  * Enables an SPI device.
@@ -86,7 +86,7 @@ int spi_delete_device(struct spi_device *dev);
  *
  * @return 0 on success, or a negative error code on failure.
  */
-int spi_enable(struct spi_device *dev);
+int lm_spi_enable(struct lm_spi_device *dev);
 
 /**
  * Disables an SPI device.
@@ -95,7 +95,7 @@ int spi_enable(struct spi_device *dev);
  *
  * @return 0 on success, or a negative error code on failure.
  */
-int spi_disable(struct spi_device *dev);
+int lm_spi_disable(struct lm_spi_device *dev);
 
 /**
  * @brief Write data to a SPI device.
@@ -109,7 +109,7 @@ int spi_disable(struct spi_device *dev);
  * @return 0 if the operation is successful, otherwise returns a non-zero error
  *         code.
  */
-int spi_write(struct spi_device *dev, const void *data, size_t data_len);
+int lm_spi_write(struct lm_spi_device *dev, const void *data, size_t data_len);
 
 /**
  * @brief Read data from a SPI device.
@@ -123,7 +123,7 @@ int spi_write(struct spi_device *dev, const void *data, size_t data_len);
  * @return 0 if the operation is successful, otherwise returns a non-zero error
  *         code.
  */
-int spi_read(struct spi_device *dev, void *buf, size_t rx_len);
+int lm_spi_read(struct lm_spi_device *dev, void *buf, size_t rx_len);
 
 /**
  * @brief Write and read data from a SPI device.
@@ -140,7 +140,7 @@ int spi_read(struct spi_device *dev, void *buf, size_t rx_len);
  * @return 0 if the operation is successful, otherwise returns a non-zero error
  *         code.
  */
-int spi_writeread(struct spi_device *dev,
+int lm_spi_writeread(struct lm_spi_device *dev,
 		const void *txdata, size_t txdata_len,
 		void *rxbuf, size_t rx_len);
 

--- a/interfaces/uart/include/libmcu/uart.h
+++ b/interfaces/uart/include/libmcu/uart.h
@@ -14,39 +14,43 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 
-struct uart;
+#if !defined(LM_GPIO_PIN_UNASSIGNED)
+#define LM_GPIO_PIN_UNASSIGNED		-1
+#endif
 
-typedef void (*uart_rx_callback_t)(struct uart *self, void *ctx);
+struct lm_uart;
 
-typedef enum {
-	UART_PARITY_NONE,
-	UART_PARITY_EVEN,
-	UART_PARITY_ODD,
-} uart_parity_t;
+typedef void (*lm_uart_rx_callback_t)(struct lm_uart *self, void *ctx);
 
 typedef enum {
-	UART_STOPBIT_1,
-	UART_STOPBIT_2,
-	UART_STOPBIT_1_5,
-} uart_stopbit_t;
+	LM_UART_PARITY_NONE,
+	LM_UART_PARITY_EVEN,
+	LM_UART_PARITY_ODD,
+} lm_uart_parity_t;
 
 typedef enum {
-	UART_FLOWCTRL_NONE,
-	UART_FLOWCTRL_RTS,
-	UART_FLOWCTRL_CTS,
-	UART_FLOWCTRL_CTS_RTS,
-} uart_flowctrl_t;
+	LM_UART_STOPBIT_1,
+	LM_UART_STOPBIT_2,
+	LM_UART_STOPBIT_1_5,
+} lm_uart_stopbit_t;
 
-struct uart_config {
+typedef enum {
+	LM_UART_FLOWCTRL_NONE,
+	LM_UART_FLOWCTRL_RTS,
+	LM_UART_FLOWCTRL_CTS,
+	LM_UART_FLOWCTRL_CTS_RTS,
+} lm_uart_flowctrl_t;
+
+struct lm_uart_config {
 	uint32_t baudrate;
 	uint8_t databit;
-	uart_parity_t parity;
-	uart_stopbit_t stopbit;
-	uart_flowctrl_t flowctrl;
+	lm_uart_parity_t parity;
+	lm_uart_stopbit_t stopbit;
+	lm_uart_flowctrl_t flowctrl;
 	uint32_t rx_timeout_ms;
 };
 
-struct uart_pin {
+struct lm_uart_pin {
 	int rx;
 	int tx;
 	int rts;
@@ -63,7 +67,7 @@ struct uart_pin {
  * @param[in] pin Pointer to the UART pin configuration structure.
  * @return Pointer to the created UART instance, or NULL on failure.
  */
-struct uart *uart_create(uint8_t channel, const struct uart_pin *pin);
+struct lm_uart *lm_uart_create(uint8_t channel, const struct lm_uart_pin *pin);
 
 /**
  * @brief Delete a UART instance.
@@ -73,7 +77,7 @@ struct uart *uart_create(uint8_t channel, const struct uart_pin *pin);
  *
  * @param[in] self Pointer to the UART instance to be deleted.
  */
-void uart_delete(struct uart *self);
+void lm_uart_delete(struct lm_uart *self);
 
 /**
  * @brief Enable the UART interface.
@@ -84,7 +88,7 @@ void uart_delete(struct uart *self);
  * @param[in] baudrate The baud rate for UART communication.
  * @return 0 on success, or a negative error code on failure.
  */
-int uart_enable(struct uart *self, uint32_t baudrate);
+int lm_uart_enable(struct lm_uart *self, uint32_t baudrate);
 
 /**
  * @brief Disable the UART interface.
@@ -94,7 +98,7 @@ int uart_enable(struct uart *self, uint32_t baudrate);
  * @param[in] self Pointer to the UART instance.
  * @return 0 on success, or a negative error code on failure.
  */
-int uart_disable(struct uart *self);
+int lm_uart_disable(struct lm_uart *self);
 
 /**
  * @brief Write data to the UART interface.
@@ -106,7 +110,7 @@ int uart_disable(struct uart *self);
  * @param[in] data_len Length of the data to be written.
  * @return Number of bytes written, or a negative error code on failure.
  */
-int uart_write(struct uart *self, const void *data, size_t data_len);
+int lm_uart_write(struct lm_uart *self, const void *data, size_t data_len);
 
 /**
  * @brief Read data from the UART interface.
@@ -118,7 +122,7 @@ int uart_write(struct uart *self, const void *data, size_t data_len);
  * @param[in] bufsize Size of the buffer.
  * @return Number of bytes read, or a negative error code on failure.
  */
-int uart_read(struct uart *self, void *buf, size_t bufsize);
+int lm_uart_read(struct lm_uart *self, void *buf, size_t bufsize);
 
 /**
  * @brief Register a callback for UART receive events.
@@ -131,8 +135,8 @@ int uart_read(struct uart *self, void *buf, size_t bufsize);
  * @param[in] cb_ctx User-defined context to be passed to the callback function.
  * @return 0 on success, or a negative error code on failure.
  */
-int uart_register_rx_callback(struct uart *self,
-		uart_rx_callback_t cb, void *cb_ctx);
+int lm_uart_register_rx_callback(struct lm_uart *self,
+		lm_uart_rx_callback_t cb, void *cb_ctx);
 
 /**
  * @brief Configure the UART interface.
@@ -143,7 +147,7 @@ int uart_register_rx_callback(struct uart *self,
  * @param[in] config Pointer to the UART configuration structure.
  * @return 0 on success, or a negative error code on failure.
  */
-int uart_configure(struct uart *self, const struct uart_config *config);
+int lm_uart_configure(struct lm_uart *self, const struct lm_uart_config *config);
 
 /**
  * @brief Flush the UART interface.
@@ -154,7 +158,7 @@ int uart_configure(struct uart *self, const struct uart_config *config);
  * @param[in] self Pointer to the UART instance.
  * @return 0 on success, or a negative error code on failure.
  */
-int uart_flush(struct uart *self);
+int lm_uart_flush(struct lm_uart *self);
 
 /**
  * @brief Clear the UART receive buffer.
@@ -165,7 +169,7 @@ int uart_flush(struct uart *self);
  * @param[in] self Pointer to the UART instance.
  * @return 0 on success, or a negative error code on failure.
  */
-int uart_clear(struct uart *self);
+int lm_uart_clear(struct lm_uart *self);
 
 #if defined(__cplusplus)
 }

--- a/modules/buzzer/README.md
+++ b/modules/buzzer/README.md
@@ -23,7 +23,7 @@ Before using the buzzer, initialize the module with the appropriate configuratio
 #define PWM_CHANNEL 1
 #define PWM_PIN     1
 
-struct pwm_channel *pwm_ch = pwm_create_channel(pwm, PWM_CHANNEL, PWM_PIN);
+struct lm_pwm_channel *pwm_ch = lm_pwm_create_channel(pwm, PWM_CHANNEL, PWM_PIN);
 
 buzzer_init(pwm_ch, 0, 0);
 ```

--- a/modules/buzzer/include/libmcu/buzzer.h
+++ b/modules/buzzer/include/libmcu/buzzer.h
@@ -12,13 +12,14 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
-#include "libmcu/pwm.h"
 #include "melody.h"
 
 typedef struct buzzer_callbacks {
 	void (*on_frequency_changed)(void *ctx, uint16_t hz);
 	void (*on_stop)(void *ctx);
 } buzzer_callback_t;
+
+struct lm_pwm_channel;
 
 /**
  * @brief Initialize the buzzer module.
@@ -28,7 +29,7 @@ typedef struct buzzer_callbacks {
  * @param[in] on_event_ctx Context pointer to be passed to the callback
  *            function.
  */
-void buzzer_init(struct pwm_channel *pwm,
+void buzzer_init(struct lm_pwm_channel *pwm,
 		buzzer_callback_t *on_event, void *on_event_ctx);
 
 /**

--- a/modules/buzzer/src/buzzer.c
+++ b/modules/buzzer/src/buzzer.c
@@ -11,6 +11,7 @@
 #include <semaphore.h>
 
 #include "libmcu/apptmr.h"
+#include "libmcu/pwm.h"
 
 struct playing {
 	const struct melody *melody;
@@ -23,7 +24,7 @@ static struct buzzer {
 	buzzer_callback_t *callback;
 	void *callback_ctx;
 
-	struct pwm_channel *pwm;
+	struct lm_pwm_channel *pwm;
 	struct apptmr *timer;
 
 	sem_t lock;
@@ -34,13 +35,13 @@ static void on_timeout(struct apptmr *timer, void *arg)
 {
 	struct buzzer *buzzer = (struct buzzer *)arg;
 	struct playing *playing = &buzzer->playing;
-	struct pwm_channel *pwm = buzzer->pwm;
+	struct lm_pwm_channel *pwm = buzzer->pwm;
 
 	const struct tone *prev = &playing->melody->tones[playing->index];
 	playing->index += 1;
 
 	if (playing->index >= playing->melody->nr_tones) {
-		pwm_stop(pwm);
+		lm_pwm_stop(pwm);
 
 		if (buzzer->callback && buzzer->callback->on_stop) {
 			buzzer->callback->on_stop(buzzer->callback_ctx);
@@ -53,12 +54,12 @@ static void on_timeout(struct apptmr *timer, void *arg)
 	tone_pitch_t pitch = tone_get(tone->note, tone->octave);
 
 	if (!pitch) {
-		pwm_update_duty(pwm, 0);
+		lm_pwm_update_duty(pwm, 0);
 	} else {
 		if (tone_get(prev->note, prev->octave) == 0) {
-			pwm_update_duty(pwm, PWM_PCT_TO_MILLI(50));
+			lm_pwm_update_duty(pwm, LM_PWM_PCT_TO_MILLI(50));
 		}
-		pwm_update_frequency(pwm, pitch);
+		lm_pwm_update_frequency(pwm, pitch);
 	}
 
 	if (buzzer->callback && buzzer->callback->on_frequency_changed) {
@@ -72,14 +73,14 @@ static void on_timeout(struct apptmr *timer, void *arg)
 static void play(struct buzzer *buzzer, const struct melody *melody)
 {
 	apptmr_stop(buzzer->timer);
-	pwm_stop(buzzer->pwm);
+	lm_pwm_stop(buzzer->pwm);
 
 	buzzer->playing.melody = melody;
 	buzzer->playing.index = 0;
 
 	const struct tone *tone = &buzzer->playing.melody->tones[0];
 	tone_pitch_t pitch = tone_get(tone->note, tone->octave);
-	pwm_start(buzzer->pwm, pitch, PWM_PCT_TO_MILLI(50));
+	lm_pwm_start(buzzer->pwm, pitch, LM_PWM_PCT_TO_MILLI(50));
 
 	apptmr_start(buzzer->timer, tone->len_ms);
 }
@@ -96,7 +97,7 @@ void buzzer_play(const struct melody *melody)
 void buzzer_mute(void)
 {
 	sem_wait(&m.lock);
-	pwm_stop(m.pwm);
+	lm_pwm_stop(m.pwm);
 	m.enabled = false;
 	sem_post(&m.lock);
 }
@@ -118,7 +119,7 @@ bool buzzer_busy(void)
 	return false;
 }
 
-void buzzer_init(struct pwm_channel *pwm,
+void buzzer_init(struct lm_pwm_channel *pwm,
 		buzzer_callback_t *on_event, void *on_event_ctx)
 {
 	sem_init(&m.lock, 0, 1);
@@ -129,7 +130,7 @@ void buzzer_init(struct pwm_channel *pwm,
 	m.pwm = pwm;
 	m.timer = apptmr_create(false, on_timeout, &m);
 
-	pwm_enable(m.pwm);
+	lm_pwm_enable(m.pwm);
 	apptmr_enable(m.timer);
 	m.enabled = true;
 }

--- a/ports/esp-idf/adc.c
+++ b/ports/esp-idf/adc.c
@@ -33,8 +33,8 @@
 #define cal_del			adc_cali_delete_scheme_line_fitting
 #endif
 
-struct adc {
-	struct adc_api api;
+struct lm_adc {
+	struct lm_adc_api api;
 
 	adc_oneshot_unit_handle_t handle;
 	adc_cali_handle_t cal_handle;
@@ -42,12 +42,12 @@ struct adc {
 	bool activated;
 };
 
-static int channel_to_esp(adc_channel_t channel)
+static int channel_to_esp(lm_adc_channel_t channel)
 {
 	return channel? __builtin_ctz(channel) + 1 : 0;
 }
 
-static int convert_to_millivolts(struct adc *self, int value)
+static int convert_to_millivolts(struct lm_adc *self, int value)
 {
 	int mv;
 
@@ -62,7 +62,7 @@ static int convert_to_millivolts(struct adc *self, int value)
 	return mv;
 }
 
-static int read_adc(struct adc *self, adc_channel_t channel)
+static int read_adc(struct lm_adc *self, lm_adc_channel_t channel)
 {
 	int adc;
 
@@ -78,7 +78,7 @@ static int read_adc(struct adc *self, adc_channel_t channel)
 	return adc;
 }
 
-static int measure(struct adc *self)
+static int measure(struct lm_adc *self)
 {
 	if (!self || !self->activated) {
 		return -EPIPE;
@@ -87,7 +87,7 @@ static int measure(struct adc *self)
 	return 0;
 }
 
-static int init_channel(struct adc *self, adc_channel_t channel)
+static int init_channel(struct lm_adc *self, lm_adc_channel_t channel)
 {
 	if (!self || !self->activated) {
 		return -EPIPE;
@@ -110,7 +110,7 @@ static int init_channel(struct adc *self, adc_channel_t channel)
 	return 0;
 }
 
-static int calibrate_adc(struct adc *self)
+static int calibrate_adc(struct lm_adc *self)
 {
 	if (!self || !self->activated) {
 		return -EPIPE;
@@ -129,7 +129,7 @@ static int calibrate_adc(struct adc *self)
 	return 0;
 }
 
-static int enable_adc(struct adc *self)
+static int enable_adc(struct lm_adc *self)
 {
 	if (!self) {
 		return -EPIPE;
@@ -149,7 +149,7 @@ static int enable_adc(struct adc *self)
 	return 0;
 }
 
-static int disable_adc(struct adc *self)
+static int disable_adc(struct lm_adc *self)
 {
 	if (!self) {
 		return -EPIPE;
@@ -164,16 +164,16 @@ static int disable_adc(struct adc *self)
 	return 0;
 }
 
-struct adc *adc_create(uint8_t adc_num)
+struct lm_adc *lm_adc_create(uint8_t adc_num)
 {
-	static struct adc adc[ADC_MAX];
+	static struct lm_adc adc[ADC_MAX];
 
 	if (--adc_num >= ADC_MAX || adc[adc_num].activated) {
 		return NULL;
 	}
 
 	for (int i = 0; i < ADC_MAX; i++) {
-		adc[i].api = (struct adc_api) {
+		adc[i].api = (struct lm_adc_api) {
 			.enable = enable_adc,
 			.disable = disable_adc,
 			.init_channel = init_channel,
@@ -189,12 +189,12 @@ struct adc *adc_create(uint8_t adc_num)
 	return &adc[adc_num];
 }
 
-int adc_delete(struct adc *self)
+int lm_adc_delete(struct lm_adc *self)
 {
 	if (!self) {
 		return -EPIPE;
 	} else if (self->activated) {
-		adc_disable(self);
+		lm_adc_disable(self);
 	}
 
 	memset(self, 0, sizeof(*self));

--- a/ports/esp-idf/uart.c
+++ b/ports/esp-idf/uart.c
@@ -4,15 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-#define UART_PARITY_EVEN	LIBMCU_UART_PARITY_EVEN
-#define UART_PARITY_ODD		LIBMCU_UART_PARITY_ODD
-#define uart_parity_t		libmcu_uart_parity_t
-#define uart_flush		libmcu_uart_flush
 #include "libmcu/uart.h"
-#undef uart_flush
-#undef uart_parity_t
-#undef UART_PARITY_ODD
-#undef UART_PARITY_EVEN
 
 #include <errno.h>
 #include <string.h>
@@ -25,30 +17,30 @@
 #define DEFAULT_RXQUEUE_LEN		8
 
 #if !defined(UART_DEFAULT_OPTION_PARITY)
-#define UART_DEFAULT_OPTION_PARITY	UART_PARITY_NONE
+#define UART_DEFAULT_OPTION_PARITY	LM_UART_PARITY_NONE
 #endif
 #if !defined(UART_DEFAULT_OPTION_DATABIT)
 #define UART_DEFAULT_OPTION_DATABIT	8
 #endif
 #if !defined(UART_DEFAULT_OPTION_STOPBIT)
-#define UART_DEFAULT_OPTION_STOPBIT	UART_STOPBIT_1
+#define UART_DEFAULT_OPTION_STOPBIT	LM_UART_STOPBIT_1
 #endif
 #if !defined(UART_DEFAULT_OPTION_FLOWCTRL)
-#define UART_DEFAULT_OPTION_FLOWCTRL	UART_FLOWCTRL_NONE
+#define UART_DEFAULT_OPTION_FLOWCTRL	LM_UART_FLOWCTRL_NONE
 #endif
 #if !defined(UART_DEFAULT_OPTION_RX_TIMEOUT)
 #define UART_DEFAULT_OPTION_RX_TIMEOUT	-1
 #endif
 
-struct uart {
-	struct uart_config config;
-	struct uart_pin pin;
+struct lm_uart {
+	struct lm_uart_config config;
+	struct lm_uart_pin pin;
 	uint8_t channel;
 	bool activated;
 };
 
 static void set_config(uart_config_t *uart_config,
-		const struct uart_config *config)
+		const struct lm_uart_config *config)
 {
 	uart_config->baud_rate = config->baudrate;
 
@@ -68,33 +60,33 @@ static void set_config(uart_config_t *uart_config,
 		break;
 	}
 
-	if (config->parity == LIBMCU_UART_PARITY_EVEN) {
+	if (config->parity == LM_UART_PARITY_EVEN) {
 		uart_config->parity = UART_PARITY_EVEN;
-	} else if (config->parity == LIBMCU_UART_PARITY_ODD) {
+	} else if (config->parity == LM_UART_PARITY_ODD) {
 		uart_config->parity = UART_PARITY_ODD;
 	} else {
 		uart_config->parity = UART_PARITY_DISABLE;
 	}
 
-	if (config->stopbit == UART_STOPBIT_1_5) {
+	if (config->stopbit == LM_UART_STOPBIT_1_5) {
 		uart_config->stop_bits = UART_STOP_BITS_1_5;
-	} else if (config->stopbit == UART_STOPBIT_2) {
+	} else if (config->stopbit == LM_UART_STOPBIT_2) {
 		uart_config->stop_bits = UART_STOP_BITS_2;
 	} else {
 		uart_config->stop_bits = UART_STOP_BITS_1;
 	}
 
 	switch (config->flowctrl) {
-	case UART_FLOWCTRL_RTS:
+	case LM_UART_FLOWCTRL_RTS:
 		uart_config->flow_ctrl = UART_HW_FLOWCTRL_RTS;
 		break;
-	case UART_FLOWCTRL_CTS:
+	case LM_UART_FLOWCTRL_CTS:
 		uart_config->flow_ctrl = UART_HW_FLOWCTRL_CTS;
 		break;
-	case UART_FLOWCTRL_CTS_RTS:
+	case LM_UART_FLOWCTRL_CTS_RTS:
 		uart_config->flow_ctrl = UART_HW_FLOWCTRL_CTS_RTS;
 		break;
-	case UART_FLOWCTRL_NONE: /* fall through */
+	case LM_UART_FLOWCTRL_NONE: /* fall through */
 	default:
 		uart_config->flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
 		break;
@@ -105,7 +97,7 @@ static void set_config(uart_config_t *uart_config,
 #endif
 }
 
-static int update_config(struct uart *self)
+static int update_config(struct lm_uart *self)
 {
 	uart_config_t uart_config = { 0, };
 	set_config(&uart_config, &self->config);
@@ -117,7 +109,7 @@ static int update_config(struct uart *self)
 	return 0;
 }
 
-int uart_configure(struct uart *self, const struct uart_config *config)
+int lm_uart_configure(struct lm_uart *self, const struct lm_uart_config *config)
 {
 	if (!self) {
 		return -EPIPE;
@@ -140,7 +132,7 @@ int uart_configure(struct uart *self, const struct uart_config *config)
 	return update_config(self);
 }
 
-int uart_write(struct uart *self, const void *data, size_t data_len)
+int lm_uart_write(struct lm_uart *self, const void *data, size_t data_len)
 {
 	if (!self || !self->activated) {
 		return -EPIPE;
@@ -162,7 +154,7 @@ int uart_write(struct uart *self, const void *data, size_t data_len)
 	return written;
 }
 
-int uart_read(struct uart *self, void *buf, size_t bufsize)
+int lm_uart_read(struct lm_uart *self, void *buf, size_t bufsize)
 {
 	if (!self || !self->activated) {
 		return -EPIPE;
@@ -178,7 +170,7 @@ int uart_read(struct uart *self, void *buf, size_t bufsize)
 	return len;
 }
 
-int libmcu_uart_flush(struct uart *self)
+int lm_uart_flush(struct lm_uart *self)
 {
 	if (!self || !self->activated) {
 		return -EPIPE;
@@ -191,7 +183,7 @@ int libmcu_uart_flush(struct uart *self)
 	return 0;
 }
 
-int uart_clear(struct uart *self)
+int lm_uart_clear(struct lm_uart *self)
 {
 	if (!self || !self->activated) {
 		return -EPIPE;
@@ -204,7 +196,7 @@ int uart_clear(struct uart *self)
 	return 0;
 }
 
-int uart_enable(struct uart *self, uint32_t baudrate)
+int lm_uart_enable(struct lm_uart *self, uint32_t baudrate)
 {
 	if (!self) {
 		return -EPIPE;
@@ -230,7 +222,7 @@ int uart_enable(struct uart *self, uint32_t baudrate)
 	return 0;
 }
 
-int uart_disable(struct uart *self)
+int lm_uart_disable(struct lm_uart *self)
 {
 	if (!self) {
 		return -EPIPE;
@@ -247,16 +239,16 @@ int uart_disable(struct uart *self)
 	return 0;
 }
 
-struct uart *uart_create(uint8_t channel, const struct uart_pin *pin)
+struct lm_uart *lm_uart_create(uint8_t channel, const struct lm_uart_pin *pin)
 {
-	static struct uart uart[MAX_UART];
+	static struct lm_uart uart[MAX_UART];
 
 	if (channel >= MAX_UART || uart[channel].activated) {
 		return NULL;
 	}
 
 	uart[channel].channel = channel;
-	uart[channel].config = (struct uart_config) {
+	uart[channel].config = (struct lm_uart_config) {
 		.databit = UART_DEFAULT_OPTION_DATABIT,
 		.parity = UART_DEFAULT_OPTION_PARITY,
 		.stopbit = UART_DEFAULT_OPTION_STOPBIT,
@@ -271,7 +263,7 @@ struct uart *uart_create(uint8_t channel, const struct uart_pin *pin)
 	return &uart[channel];
 }
 
-void uart_delete(struct uart *self)
+void lm_uart_delete(struct lm_uart *self)
 {
 	memset(self, 0, sizeof(*self));
 }

--- a/ports/esp-idf/wdt.c
+++ b/ports/esp-idf/wdt.c
@@ -98,7 +98,7 @@ static void *wdt_task(void *e)
 				board_get_time_since_boot_ms());
 
 		if (wdt) {
-			WDT_ERROR("wdt %s timed out", wdt->name);
+			WDT_ERROR("wdt \"%s\" timed out", wdt->name);
 
 			if (wdt->cb) {
 				(*wdt->cb)(wdt, wdt->cb_ctx);

--- a/tests/mocks/gpio.cpp
+++ b/tests/mocks/gpio.cpp
@@ -2,45 +2,45 @@
 #include "libmcu/gpio.h"
 #include "bytearray.h"
 
-struct gpio {
-	struct gpio_api api;
+struct lm_gpio {
+	struct lm_gpio_api api;
 };
 
-static int enable_gpio(struct gpio *self) {
-	return mock().actualCall("gpio_enable").withParameter("self", self)
+static int enable_gpio(struct lm_gpio *self) {
+	return mock().actualCall("lm_gpio_enable").withParameter("self", self)
 		.returnIntValue();
 }
 
-static int disable_gpio(struct gpio *self) {
-	return mock().actualCall("gpio_disable").withParameter("self", self)
+static int disable_gpio(struct lm_gpio *self) {
+	return mock().actualCall("lm_gpio_disable").withParameter("self", self)
 		.returnIntValue();
 }
 
-static int set_gpio(struct gpio *self, int value) {
-	return mock().actualCall("gpio_set")
+static int set_gpio(struct lm_gpio *self, int value) {
+	return mock().actualCall("lm_gpio_set")
 		.withParameter("self", self)
 		.withParameter("value", value)
 		.returnIntValue();
 }
 
-static int get_gpio(struct gpio *self) {
-	return mock().actualCall("gpio_get")
+static int get_gpio(struct lm_gpio *self) {
+	return mock().actualCall("lm_gpio_get")
 		.withParameter("self", self)
 		.returnIntValue();
 }
 
-static int register_callback(struct gpio *self, gpio_callback_t cb, void *cb_ctx) {
-	return mock().actualCall("gpio_register_callback")
+static int register_callback(struct lm_gpio *self, lm_gpio_callback_t cb, void *cb_ctx) {
+	return mock().actualCall("lm_gpio_register_callback")
 		.withParameter("self", self)
 		.withParameter("cb", cb)
 		.withParameter("cb_ctx", cb_ctx)
 		.returnIntValue();
 }
 
-struct gpio *gpio_create(uint16_t pin) {
+struct lm_gpio *lm_gpio_create(uint16_t pin) {
 	(void)pin;
 
-	static struct gpio gpio = {
+	static struct lm_gpio gpio = {
 		.api = {
 			.enable = enable_gpio,
 			.disable = disable_gpio,
@@ -53,6 +53,6 @@ struct gpio *gpio_create(uint16_t pin) {
 	return &gpio;
 }
 
-void gpio_delete(struct gpio *self) {
+void lm_gpio_delete(struct lm_gpio *self) {
 	mock().actualCall(__func__).withParameter("self", self);
 }

--- a/tests/mocks/pwm.cpp
+++ b/tests/mocks/pwm.cpp
@@ -1,75 +1,75 @@
 #include "CppUTestExt/MockSupport.h"
 #include "libmcu/pwm.h"
 
-struct pwm_channel {
+struct lm_pwm_channel {
 	int dummy;
 };
 
-struct pwm {
-	struct pwm_channel dummy;
+struct lm_pwm {
+	struct lm_pwm_channel dummy;
 };
 
-struct pwm *pwm_create(uint8_t timer) {
-	return (struct pwm *)mock().actualCall("pwm_create")
+struct lm_pwm *lm_pwm_create(uint8_t timer) {
+	return (struct lm_pwm *)mock().actualCall("lm_pwm_create")
 		.withParameter("timer", timer)
 		.returnPointerValue();
 }
 
-int pwm_delete(struct pwm *self) {
-	return mock().actualCall("pwm_delete")
+int lm_pwm_delete(struct lm_pwm *self) {
+	return mock().actualCall("lm_pwm_delete")
 		.withParameter("self", self)
 		.returnIntValue();
 }
 
-struct pwm_channel *pwm_create_channel(struct pwm *self, int ch, int pin) {
-	return (struct pwm_channel *)mock().actualCall("pwm_create_channel")
+struct lm_pwm_channel *lm_pwm_create_channel(struct lm_pwm *self, int ch, int pin) {
+	return (struct lm_pwm_channel *)mock().actualCall("lm_pwm_create_channel")
 		.withParameter("self", self)
 		.withParameter("ch", ch)
 		.withParameter("pin", pin)
 		.returnPointerValue();
 }
 
-int pwm_delete_channel(struct pwm_channel *ch) {
-	return mock().actualCall("pwm_delete_channel")
+int lm_pwm_delete_channel(struct lm_pwm_channel *ch) {
+	return mock().actualCall("lm_pwm_delete_channel")
 		.withParameter("ch", ch)
 		.returnIntValue();
 }
 
-int pwm_enable(struct pwm_channel *ch) {
-	return mock().actualCall("pwm_enable")
+int lm_pwm_enable(struct lm_pwm_channel *ch) {
+	return mock().actualCall("lm_pwm_enable")
 		.withParameter("ch", ch)
 		.returnIntValue();
 }
 
-int pwm_disable(struct pwm_channel *ch) {
-	return mock().actualCall("pwm_disable")
+int lm_pwm_disable(struct lm_pwm_channel *ch) {
+	return mock().actualCall("lm_pwm_disable")
 		.withParameter("ch", ch)
 		.returnIntValue();
 }
 
-int pwm_start(struct pwm_channel *ch, uint32_t freq_hz, uint32_t duty_millipercent) {
-	return mock().actualCall("pwm_start")
+int lm_pwm_start(struct lm_pwm_channel *ch, uint32_t freq_hz, uint32_t duty_millipercent) {
+	return mock().actualCall("lm_pwm_start")
 		.withParameter("ch", ch)
 		.withParameter("freq_hz", freq_hz)
 		.withParameter("duty_millipercent", duty_millipercent)
 		.returnIntValue();
 }
 
-int pwm_stop(struct pwm_channel *ch) {
-	return mock().actualCall("pwm_stop")
+int lm_pwm_stop(struct lm_pwm_channel *ch) {
+	return mock().actualCall("lm_pwm_stop")
 		.withParameter("ch", ch)
 		.returnIntValue();
 }
 
-int pwm_update_frequency(struct pwm_channel *ch, uint32_t hz) {
-	return mock().actualCall("pwm_update_frequency")
+int lm_pwm_update_frequency(struct lm_pwm_channel *ch, uint32_t hz) {
+	return mock().actualCall("lm_pwm_update_frequency")
 		.withParameter("ch", ch)
 		.withParameter("hz", hz)
 		.returnIntValue();
 }
 
-int pwm_update_duty(struct pwm_channel *ch, uint32_t millipercent) {
-	return mock().actualCall("pwm_update_duty")
+int lm_pwm_update_duty(struct lm_pwm_channel *ch, uint32_t millipercent) {
+	return mock().actualCall("lm_pwm_update_duty")
 		.withParameter("ch", ch)
 		.withParameter("millipercent", millipercent)
 		.returnIntValue();


### PR DESCRIPTION
This pull request includes several changes to the `libmcu` library, focusing on renaming structures and functions to follow a consistent naming convention across different modules. The changes affect the `adc`, `gpio`, `i2c`, `pwm`, and `spi` interfaces. Additionally, a new function is added to the `memory_kvstore` example.

### Naming Convention Updates:

* [`interfaces/adc/include/libmcu/adc.h`](diffhunk://#diff-6980d0ddc3251ed0fe3005533fbcd06e3a95dcd44079fbd28363d58f92bf0d91L16-R82): Renamed structures and functions to use the `lm_adc` prefix.
* [`interfaces/gpio/include/libmcu/gpio.h`](diffhunk://#diff-1169c94f6b745dbdd8a13bb8a5f7430c4c8804d24619b97ece4f81f1c6dd7ad3L17-R62): Renamed structures and functions to use the `lm_gpio` prefix.
* [`interfaces/i2c/include/libmcu/i2c.h`](diffhunk://#diff-d82d72e41156eb7da0890bb69fa2539c9b9485d72e3c518f912f6ffd39c24ebeL18-R98): Renamed structures and functions to use the `lm_i2c` prefix.
* [`interfaces/pwm/include/libmcu/pwm.h`](diffhunk://#diff-98bea863f812f0ddf7cd8f0c6425d7d2dbde46ba1ce3e57d832b095c046e77f2L17-R21): Renamed structures and functions to use the `lm_pwm` prefix. [[1]](diffhunk://#diff-98bea863f812f0ddf7cd8f0c6425d7d2dbde46ba1ce3e57d832b095c046e77f2L17-R21) [[2]](diffhunk://#diff-98bea863f812f0ddf7cd8f0c6425d7d2dbde46ba1ce3e57d832b095c046e77f2L33-R33) [[3]](diffhunk://#diff-98bea863f812f0ddf7cd8f0c6425d7d2dbde46ba1ce3e57d832b095c046e77f2L44-R44) [[4]](diffhunk://#diff-98bea863f812f0ddf7cd8f0c6425d7d2dbde46ba1ce3e57d832b095c046e77f2L55-R56) [[5]](diffhunk://#diff-98bea863f812f0ddf7cd8f0c6425d7d2dbde46ba1ce3e57d832b095c046e77f2L64-R65) [[6]](diffhunk://#diff-98bea863f812f0ddf7cd8f0c6425d7d2dbde46ba1ce3e57d832b095c046e77f2L73-R74) [[7]](diffhunk://#diff-98bea863f812f0ddf7cd8f0c6425d7d2dbde46ba1ce3e57d832b095c046e77f2L82-R83) [[8]](diffhunk://#diff-98bea863f812f0ddf7cd8f0c6425d7d2dbde46ba1ce3e57d832b095c046e77f2L95-R97) [[9]](diffhunk://#diff-98bea863f812f0ddf7cd8f0c6425d7d2dbde46ba1ce3e57d832b095c046e77f2L106-R108) [[10]](diffhunk://#diff-98bea863f812f0ddf7cd8f0c6425d7d2dbde46ba1ce3e57d832b095c046e77f2L118-R120) [[11]](diffhunk://#diff-98bea863f812f0ddf7cd8f0c6425d7d2dbde46ba1ce3e57d832b095c046e77f2L130-R132)
* [`interfaces/spi/include/libmcu/spi.h`](diffhunk://#diff-2100b036dba47edf75b3e75c46c178673e25f4ba2debdca5278e3f840558e448L17-R35): Renamed structures and functions to use the `lm_spi` prefix. [[1]](diffhunk://#diff-2100b036dba47edf75b3e75c46c178673e25f4ba2debdca5278e3f840558e448L17-R35) [[2]](diffhunk://#diff-2100b036dba47edf75b3e75c46c178673e25f4ba2debdca5278e3f840558e448L49-R49) [[3]](diffhunk://#diff-2100b036dba47edf75b3e75c46c178673e25f4ba2debdca5278e3f840558e448L58-R58) [[4]](diffhunk://#diff-2100b036dba47edf75b3e75c46c178673e25f4ba2debdca5278e3f840558e448L70-R71) [[5]](diffhunk://#diff-2100b036dba47edf75b3e75c46c178673e25f4ba2debdca5278e3f840558e448L80-R80) [[6]](diffhunk://#diff-2100b036dba47edf75b3e75c46c178673e25f4ba2debdca5278e3f840558e448L89-R89) [[7]](diffhunk://#diff-2100b036dba47edf75b3e75c46c178673e25f4ba2debdca5278e3f840558e448L98-R98)

### New Function Addition:

* [`examples/memory_kvstore.c`](diffhunk://#diff-d8d10310d8bb2855156f5f164c67981bb93a101c673d68b98a41df7064d506a3R124-R129): Added the `memory_kvstore_open` function and updated the `memory_kvstore_create` function to include this new function. [[1]](diffhunk://#diff-d8d10310d8bb2855156f5f164c67981bb93a101c673d68b98a41df7064d506a3R124-R129) [[2]](diffhunk://#diff-d8d10310d8bb2855156f5f164c67981bb93a101c673d68b98a41df7064d506a3R167)