### PR TITLE
refactor(cli, common): update types to use uint32_t for type consistency

### DIFF
--- a/modules/cli/include/libmcu/cli_cmd_macro.h
+++ b/modules/cli/include/libmcu/cli_cmd_macro.h
@@ -122,9 +122,14 @@ extern "C" {
 	CLI_CPP_EXPAND_NESTED(macroname, (a1)) CLI_CPP_COMMA \
 	CLI_CPP_APPLY_31(macroname, a2,a3,a4,a5,a6,a7,a8,a9,a10,a11,a12,a13,a14,a15,a16,a17,a18,a19,a20,a21,a22,a23,a24,a25,a26,a27,a28,a29,a30,a31,a32)
 
+#define CLI_CPP_NARG_(...)		CLI_CPP_ARG_N(__VA_ARGS__)
+#if defined(__clang__)
+#define CLI_CPP_NARG(...)		\
+	CLI_CPP_NARG_(__VA_OPT__(_0, ) __VA_ARGS__, CLI_CPP_RSEQ_N())
+#else
 #define CLI_CPP_NARG(...)		\
 	CLI_CPP_NARG_(_0, ## __VA_ARGS__, CLI_CPP_RSEQ_N())
-#define CLI_CPP_NARG_(...)		CLI_CPP_ARG_N(__VA_ARGS__)
+#endif
 
 #define CLI_CPP_REF			&
 #define CLI_CPP_COMMA			,

--- a/modules/common/include/libmcu/board.h
+++ b/modules/common/include/libmcu/board.h
@@ -42,7 +42,7 @@ const char *board_name(void);
 board_reboot_reason_t board_get_reboot_reason(void);
 const char *board_get_reboot_reason_string(board_reboot_reason_t reason);
 
-unsigned long board_get_time_since_boot_ms(void);
+uint32_t board_get_time_since_boot_ms(void);
 uint64_t board_get_time_since_boot_us(void);
 
 int board_register_idle_hook(int opt, board_idle_hook_t func);
@@ -61,10 +61,10 @@ uint32_t board_random(void);
  */
 uint8_t board_cpuload(int core_id, uint32_t period_sec);
 
-unsigned long board_get_free_heap_bytes(void);
-unsigned long board_get_total_heap_bytes(void);
-unsigned long board_get_heap_watermark(void);
-unsigned long board_get_current_stack_watermark(void);
+uint32_t board_get_free_heap_bytes(void);
+uint32_t board_get_total_heap_bytes(void);
+uint32_t board_get_heap_watermark(void);
+uint32_t board_get_current_stack_watermark(void);
 
 void *board_get_current_thread(void);
 

--- a/modules/common/include/libmcu/timext.h
+++ b/modules/common/include/libmcu/timext.h
@@ -11,13 +11,14 @@
 extern "C" {
 #endif
 
+#include <stdint.h>
 #include <stdbool.h>
 #include <time.h>
 
-void timeout_set(unsigned long *goal, unsigned long msec);
-bool timeout_is_expired(unsigned long goal);
+void timeout_set(uint32_t *goal, uint32_t msec);
+bool timeout_is_expired(uint32_t goal);
 
-void sleep_ms(unsigned long msec);
+void sleep_ms(uint32_t msec);
 
 #if defined(_GNU_SOURCE)
 /**

--- a/modules/common/src/board.c
+++ b/modules/common/src/board.c
@@ -74,7 +74,7 @@ void board_init(void)
 
 LIBMCU_WEAK
 LIBMCU_NO_INSTRUMENT
-unsigned long board_get_time_since_boot_ms(void)
+uint32_t board_get_time_since_boot_ms(void)
 {
 	return 0;
 }
@@ -86,20 +86,20 @@ uint32_t board_random(void)
 }
 
 LIBMCU_WEAK
-unsigned long board_get_free_heap_bytes(void)
+uint32_t board_get_free_heap_bytes(void)
 {
 	return 0;
 }
 
 LIBMCU_WEAK
-unsigned long board_get_heap_watermark(void)
+uint32_t board_get_heap_watermark(void)
 {
 	return 0;
 }
 
 LIBMCU_WEAK
 LIBMCU_NO_INSTRUMENT
-unsigned long board_get_current_stack_watermark(void)
+uint32_t board_get_current_stack_watermark(void)
 {
 	return 0;
 }

--- a/modules/logging/include/libmcu/logging.h
+++ b/modules/logging/include/libmcu/logging.h
@@ -49,7 +49,7 @@ struct logging_context {
 	const void *lr;
 };
 
-typedef unsigned long (*logging_time_func_t)(void);
+typedef uint32_t (*logging_time_func_t)(void);
 
 #if !defined(get_program_counter)
 #define get_program_counter()		libmcu_get_pc()

--- a/tests/src/logging/logging_test.cpp
+++ b/tests/src/logging/logging_test.cpp
@@ -14,9 +14,9 @@
 
 static const char *TAG = "logging";
 
-static unsigned long get_time(void) {
-	return (unsigned long)mock().actualCall(__func__)
-		.returnLongIntValueOrDefault(0);
+static uint32_t get_time(void) {
+	return (uint32_t)mock().actualCall(__func__)
+		.returnUnsignedIntValueOrDefault(0);
 }
 static size_t backend_write(const void *data, size_t datasize) {
 	return mock().actualCall(__func__)

--- a/tests/src/trace/trace_test.cpp
+++ b/tests/src/trace/trace_test.cpp
@@ -14,9 +14,9 @@
 
 // stubs for dependancies
 extern "C" {
-LIBMCU_NO_INSTRUMENT unsigned long board_get_time_since_boot_ms(void) { return 0; }
+LIBMCU_NO_INSTRUMENT uint32_t board_get_time_since_boot_ms(void) { return 0; }
 LIBMCU_NO_INSTRUMENT
-unsigned long board_get_current_stack_watermark(void) { return 0; }
+uint32_t board_get_current_stack_watermark(void) { return 0; }
 LIBMCU_NO_INSTRUMENT void *board_get_current_thread(void) { return 0; }
 }
 


### PR DESCRIPTION
This pull request includes several changes to improve type consistency across the codebase by replacing `unsigned long` with `uint32_t` and adding support for Clang in the CLI macros. The most important changes include updates to function signatures, macro definitions, and type definitions.

Type consistency improvements:

* [`modules/common/include/libmcu/board.h`](diffhunk://#diff-1e5b02b71826ba33a41a6e46b0c8164e2fb75fc8efa39cc3fe6f6640db54c38eL45-R45): Updated function return types from `unsigned long` to `uint32_t` for several functions, including `board_get_time_since_boot_ms`, `board_get_free_heap_bytes`, `board_get_total_heap_bytes`, `board_get_heap_watermark`, and `board_get_current_stack_watermark`. [[1]](diffhunk://#diff-1e5b02b71826ba33a41a6e46b0c8164e2fb75fc8efa39cc3fe6f6640db54c38eL45-R45) [[2]](diffhunk://#diff-1e5b02b71826ba33a41a6e46b0c8164e2fb75fc8efa39cc3fe6f6640db54c38eL64-R67)
* [`modules/common/include/libmcu/timext.h`](diffhunk://#diff-5145b19d2bd293d5524e882f99d1403459ae1ad5ff2f87f25b9f323bd2916917R14-R21): Updated function parameter and return types from `unsigned long` to `uint32_t` for `timeout_set`, `timeout_is_expired`, and `sleep_ms`.
* [`modules/logging/include/libmcu/logging.h`](diffhunk://#diff-33fcc1d2d10c5746aaa5713a873c405ceb2accbce4707eb241ac01c383f45464L52-R52): Changed the type definition of `logging_time_func_t` from `unsigned long` to `uint32_t`.

Support for Clang in CLI macros:

* [`modules/cli/include/libmcu/cli_cmd_macro.h`](diffhunk://#diff-76921a0c7d396d1d3ce8c15b4b3f075c789423ada94b5f6350e15466293d4e21R125-R132): Added conditional compilation to support Clang in the `CLI_CPP_NARG` macro.

Implementation updates:

* [`modules/common/src/board.c`](diffhunk://#diff-3e422c840efa1f2b7afc65a96423924f57fcc8d62ab72584898277b52c521b64L77-R77): Updated the implementation of functions to reflect the type changes from `unsigned long` to `uint32_t`. [[1]](diffhunk://#diff-3e422c840efa1f2b7afc65a96423924f57fcc8d62ab72584898277b52c521b64L77-R77) [[2]](diffhunk://#diff-3e422c840efa1f2b7afc65a96423924f57fcc8d62ab72584898277b52c521b64L89-R102)