### PR TITLE
feat: add semaphore implementation for Apple platform

### DIFF
--- a/examples/memory_kvstore.c
+++ b/examples/memory_kvstore.c
@@ -42,7 +42,7 @@ static struct kvstore *find_namespace(char const *namespace)
 	struct list *p;
 	list_for_each(p, &namespace_list_head) {
 		struct kvstore *obj =
-			list_entry(p, typeof(*obj), namespace_list);
+			list_entry(p, struct kvstore, namespace_list);
 		if (!strncmp(obj->namespace, namespace,
 					KVSTORE_MAX_NAMESPACE_LENGTH)) {
 			return obj;
@@ -57,7 +57,7 @@ static struct memory_kvstore_entry *find_key(struct kvstore const *obj,
 	struct list *p;
 	list_for_each(p, &obj->keylist_head) {
 		struct memory_kvstore_entry *entry =
-			list_entry(p, typeof(*entry), list);
+			list_entry(p, struct memory_kvstore_entry, list);
 		if (!strncmp(entry->key, key, KVSTORE_MAX_KEY_LENGTH)) {
 			return entry;
 		}
@@ -124,6 +124,7 @@ static int memory_kvstore_read(struct kvstore *kvstore,
 static int memory_kvstore_open(struct kvstore *kvstore, const char *ns)
 {
 	(void)kvstore;
+	(void)ns;
 	return 0;
 }
 
@@ -133,7 +134,7 @@ void memory_kvstore_destroy(struct kvstore *kvstore)
 
 	list_for_each_safe(p, n, &kvstore->keylist_head) {
 		struct memory_kvstore_entry *entry =
-			list_entry(p, typeof(*entry), list);
+			list_entry(p, struct memory_kvstore_entry, list);
 		free(entry->key);
 		free(entry->value);
 		free(entry);

--- a/ports/apple/semaphore.c
+++ b/ports/apple/semaphore.c
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: 2025 권경환 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dispatch/dispatch.h>
+#include <semaphore.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#define MAX_SEMAPHORES		64
+
+typedef struct {
+	int used;
+	sem_t *key;
+	dispatch_semaphore_t value;
+} mac_sem_entry_t;
+
+static mac_sem_entry_t table[MAX_SEMAPHORES];
+static pthread_mutex_t table_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static int insert(sem_t *key, dispatch_semaphore_t sem)
+{
+	pthread_mutex_lock(&table_lock);
+	for (int i = 0; i < MAX_SEMAPHORES; ++i) {
+		if (!table[i].used) {
+			table[i].used = 1;
+			table[i].key = key;
+			table[i].value = sem;
+			pthread_mutex_unlock(&table_lock);
+			return 0;
+		}
+	}
+	pthread_mutex_unlock(&table_lock);
+	return -1;
+}
+
+static dispatch_semaphore_t lookup(sem_t *key)
+{
+	dispatch_semaphore_t result = NULL;
+	pthread_mutex_lock(&table_lock);
+	for (int i = 0; i < MAX_SEMAPHORES; ++i) {
+		if (table[i].used && table[i].key == key) {
+			result = table[i].value;
+			break;
+		}
+	}
+	pthread_mutex_unlock(&table_lock);
+	return result;
+}
+
+static void remove_entry(sem_t *key)
+{
+	pthread_mutex_lock(&table_lock);
+	for (int i = 0; i < MAX_SEMAPHORES; ++i) {
+		if (table[i].used && table[i].key == key) {
+			table[i].used = 0;
+			table[i].key = NULL;
+			table[i].value = NULL;
+			break;
+		}
+	}
+	pthread_mutex_unlock(&table_lock);
+}
+
+int sem_init(sem_t *sem, int pshared, unsigned int value)
+{
+	if (pshared != 0) {
+		errno = ENOTSUP;
+		return -1;
+	}
+
+	dispatch_semaphore_t dsem = dispatch_semaphore_create(value);
+	if (!dsem) {
+		errno = ENOMEM;
+		return -1;
+	}
+
+	if (insert(sem, dsem) != 0) {
+		dispatch_release(dsem);
+		errno = ENOMEM;
+		return -1;
+	}
+
+	return 0;
+}
+
+int sem_destroy(sem_t *sem)
+{
+	remove_entry(sem);
+	return 0;
+}
+
+int sem_post(sem_t *sem)
+{
+	dispatch_semaphore_t dsem = lookup(sem);
+	if (!dsem) {
+		errno = EINVAL;
+		return -1;
+	}
+	dispatch_semaphore_signal(dsem);
+	return 0;
+}
+
+int sem_wait(sem_t *sem)
+{
+	dispatch_semaphore_t dsem = lookup(sem);
+	if (!dsem) {
+		errno = EINVAL;
+		return -1;
+	}
+	dispatch_semaphore_wait(dsem, DISPATCH_TIME_FOREVER);
+	return 0;
+}

--- a/ports/posix/actor.c
+++ b/ports/posix/actor.c
@@ -5,16 +5,71 @@
  */
 
 #include "libmcu/actor_overrides.h"
-#include <pthread.h>
+#include "libmcu/actor_timer.h"
 
-static pthread_mutex_t fallback_lock = PTHREAD_MUTEX_INITIALIZER;
+#include <pthread.h>
+#include <time.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#if !defined(ACTOR_TIMER_INTERVAL_MS)
+#define ACTOR_TIMER_INTERVAL_MS		50UL
+#endif
+
+static pthread_mutex_t actor_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_t timer_thread;
+static bool timer_thread_running = false;
+
+static void loop(struct timespec *curr, struct timespec *prev,
+		struct timespec *interval)
+{
+	nanosleep(interval, NULL);
+
+	clock_gettime(CLOCK_MONOTONIC, curr);
+
+	int64_t delta_sec = (int64_t)(curr->tv_sec - prev->tv_sec);
+	int64_t delta_nsec = (int64_t)(curr->tv_nsec - prev->tv_nsec);
+	uint64_t elapsed_ns = (uint64_t)(delta_sec * 1000000000LL + delta_nsec);
+	uint32_t elapsed_ms = (uint32_t)(elapsed_ns / 1000000ULL);
+
+	if (elapsed_ms > 0) {
+		actor_timer_step(elapsed_ms);
+	}
+
+	*prev = *curr;
+}
+
+static void *timer_loop(void *arg)
+{
+	(void)arg;
+
+	struct timespec interval;
+	interval.tv_sec = ACTOR_TIMER_INTERVAL_MS / 1000;
+	interval.tv_nsec = (ACTOR_TIMER_INTERVAL_MS % 1000) * 1000000L;
+
+	struct timespec prev_time, curr_time;
+	clock_gettime(CLOCK_MONOTONIC, &prev_time);
+
+	while (timer_thread_running) {
+		loop(&curr_time, &prev_time, &interval);
+	}
+
+	return NULL;
+}
+
+void actor_timer_boot(void)
+{
+	timer_thread_running = true;
+	pthread_create(&timer_thread, NULL, timer_loop, NULL);
+	pthread_detach(timer_thread);
+}
 
 void actor_lock(void)
 {
-	pthread_mutex_lock(&fallback_lock);
+	pthread_mutex_lock(&actor_mutex);
 }
 
 void actor_unlock(void)
 {
-	pthread_mutex_unlock(&fallback_lock);
+	pthread_mutex_unlock(&actor_mutex);
 }


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and maintainability of the codebase. The most important changes include updates to type usage in `memory_kvstore.c`, the addition of semaphore handling for macOS, and the introduction of a timer mechanism in the POSIX actor implementation.

Type Usage Updates:
* [`examples/memory_kvstore.c`](diffhunk://#diff-d8d10310d8bb2855156f5f164c67981bb93a101c673d68b98a41df7064d506a3L45-R45): Replaced `typeof(*obj)` and `typeof(*entry)` with explicit type names `struct kvstore` and `struct memory_kvstore_entry` in the `find_namespace`, `find_key`, and `memory_kvstore_destroy` functions. [[1]](diffhunk://#diff-d8d10310d8bb2855156f5f164c67981bb93a101c673d68b98a41df7064d506a3L45-R45) [[2]](diffhunk://#diff-d8d10310d8bb2855156f5f164c67981bb93a101c673d68b98a41df7064d506a3L60-R60) [[3]](diffhunk://#diff-d8d10310d8bb2855156f5f164c67981bb93a101c673d68b98a41df7064d506a3L136-R137)

Semaphore Handling for macOS:
* [`ports/apple/semaphore.c`](diffhunk://#diff-2a4e13377b8611c80fd59fbb18a5f7b255b2b6f1277628f056caca0ffd2200dfR1-R119): Added a new implementation for semaphore handling using `dispatch_semaphore_t`, including functions for semaphore initialization, destruction, posting, and waiting.

Timer Mechanism in POSIX Actor:
* [`ports/posix/actor.c`](diffhunk://#diff-171a5103521af2d7b5e4457d530738db131eca9340f5c5d4d982ff4e1f02a78dR8-R74): Introduced a timer mechanism using `pthread` and `clock_gettime` to periodically call `actor_timer_step`, and updated the actor lock to use a new mutex.

Minor Improvements:
* [`examples/memory_kvstore.c`](diffhunk://#diff-d8d10310d8bb2855156f5f164c67981bb93a101c673d68b98a41df7064d506a3R127): Added a cast to avoid unused parameter warning in `memory_kvstore_open`.