### PR TITLE
feat(cli): add DEL key support and fix buffer handling

### DIFF
--- a/modules/cli/src/cli.c
+++ b/modules/cli/src/cli.c
@@ -36,6 +36,7 @@ enum cli_special_key {
 	CTRL_N = 0x0E, /* down */
 	CTRL_P = 0x10, /* up */
 	ESC    = 0x1B,
+	DEL    = 0x7F, /* del */
 };
 
 enum cli_escape_char {
@@ -196,12 +197,13 @@ static char *readline(struct cli *cli)
 			break;
 		}
 
-		buf[(*pos)++] = '\0';
+		buf[*pos] = '\0';
 		*pos = 0;
+		res = buf;
 
 		cli->io->write("\n", 1);
-		res = buf;
 		break;
+	case DEL: /* fall through */
 	case '\b': /* backspace */
 		if (*pos > 0) {
 			(*pos)--;


### PR DESCRIPTION
This pull request includes changes to the `modules/cli/src/cli.c` file to add support for the `DEL` key and improve the handling of the readline buffer. The most important changes include adding a new key to the `cli_special_key` enum and modifying the `readline` function to handle the `DEL` key.

Enhancements to key handling:

* [`modules/cli/src/cli.c`](diffhunk://#diff-f9799fa55c35ec47020b5358b252cf5e2ae03a2f68f86b4b92949f80bae6ff42R39): Added `DEL` key to the `enum cli_special_key` to support deletion.

Improvements to buffer handling:

* [`modules/cli/src/cli.c`](diffhunk://#diff-f9799fa55c35ec47020b5358b252cf5e2ae03a2f68f86b4b92949f80bae6ff42L199-R206): Modified the `readline` function to correctly handle the buffer and position when the `DEL` key is pressed.