### PR TITLE
fix(list): make list_count accept const list pointer

### DIFF
--- a/modules/common/include/libmcu/list.h
+++ b/modules/common/include/libmcu/list.h
@@ -77,9 +77,9 @@ static inline LIBMCU_ALWAYS_INLINE bool list_empty(const struct list *head)
 	return false;
 }
 
-static inline LIBMCU_ALWAYS_INLINE int list_count(struct list *head)
+static inline LIBMCU_ALWAYS_INLINE int list_count(const struct list *head)
 {
-	struct list *p;
+	const struct list *p;
 	int n = 0;
 	list_for_each(p, head) {
 		n++;


### PR DESCRIPTION
This pull request makes a minor change to the `list_count` function in `modules/common/include/libmcu/list.h` to improve const-correctness by marking the `head` parameter as `const`.

* [`modules/common/include/libmcu/list.h`](diffhunk://#diff-e7eb1070952600c62bb086ed988a261a23b814ea885c87595132f39d65cbd301L80-R80): Updated the `list_count` function to use a `const struct list *head` parameter, ensuring the function does not modify the list passed to it.