### PR TITLE
feat(esp-idf): map ESP errors to errno in nvs_kvstore

### DIFF
--- a/ports/esp-idf/nvs_kvstore.c
+++ b/ports/esp-idf/nvs_kvstore.c
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: MIT
  */
 
-// maximum key and namespace string length is 15 bytes
+/* NOTE: maximum key and namespace string length is 15 bytes */
 #include "libmcu/nvs_kvstore.h"
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <errno.h>
 
 #include "esp_system.h"
 #include "nvs_flash.h"
@@ -21,10 +22,28 @@ struct kvstore {
 	nvs_handle_t handle;
 };
 
+static int esperr_to_errno(esp_err_t err)
+{
+	switch (err) {
+	case ESP_OK:
+		return 0;
+	case ESP_ERR_NVS_NOT_INITIALIZED:
+		return -ENODEV; /* NVS not initialized */
+	case ESP_ERR_NVS_NOT_FOUND:
+		return -ENOENT; /* Key or namespace not found */
+	case ESP_ERR_NVS_INVALID_NAME:
+		return -EINVAL; /* Invalid key or namespace name */
+	case ESP_ERR_NVS_INVALID_LENGTH:
+		return -E2BIG; /* Key or value too long */
+	default:
+		return -EIO; /* General I/O error */
+	}
+}
+
 static int nvs_storage_open(char const *namespace, nvs_handle_t *namespace_handle)
 {
 	int err = nvs_open(namespace, NVS_READWRITE, namespace_handle);
-	return err == ESP_OK? 0 : -err;
+	return esperr_to_errno(err);
 }
 
 static void nvs_storage_close(nvs_handle_t *namespace_handle)
@@ -40,25 +59,25 @@ static int nvs_kvstore_write(struct kvstore *self, char const *key, void const *
 		err = nvs_commit(self->handle);
 	}
 
-	return err == ESP_OK? size : -err;
+	return err == ESP_OK? (int)size : esperr_to_errno(err);
 }
 
 static int nvs_kvstore_read(struct kvstore *self, char const *key, void *buf, size_t size)
 {
 	int err = nvs_get_blob(self->handle, key, buf, &size);
-	return err == ESP_OK? size : -err;
+	return err == ESP_OK? (int)size : esperr_to_errno(err);
 }
 
 static int nvs_kvstore_erase(struct kvstore *self, char const *key)
 {
 	int err = nvs_erase_key(self->handle, key);
-	return err == ESP_OK? 0 : -err;
+	return esperr_to_errno(err);
 }
 
 static int nvs_kvstore_open(struct kvstore *self, char const *namespace)
 {
 	int err = nvs_storage_open(namespace, &self->handle);
-	return err == ESP_OK? 0 : -err;
+	return esperr_to_errno(err);
 }
 
 static void nvs_kvstore_close(struct kvstore *self)


### PR DESCRIPTION
This pull request improves error handling in the `nvs_kvstore` implementation by introducing a helper function to map ESP-IDF error codes to standard `errno` values. It also updates several functions to use this new error mapping for consistency and better error reporting.

### Enhancements to error handling:

* **Added `esperr_to_errno` helper function**: Introduced a static function to convert ESP-IDF error codes (`esp_err_t`) into standard `errno` values, improving code readability and maintainability.

* **Updated return logic in key functions**: Modified the return statements in `nvs_storage_open`, `nvs_kvstore_write`, `nvs_kvstore_read`, `nvs_kvstore_erase`, and `nvs_kvstore_open` to use the new `esperr_to_errno` function for consistent error handling.

### Minor improvements:

* **Comment style adjustment**: Updated the comment about maximum key and namespace string length to use a block comment format for consistency.

* **Header inclusion**: Added the `<errno.h>` header to support the new error mapping functionality.