### PR TITLE
feat(wifi): add IP information to wifi interface

### DIFF
--- a/interfaces/wifi/include/libmcu/wifi.h
+++ b/interfaces/wifi/include/libmcu/wifi.h
@@ -12,6 +12,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include "libmcu/ip.h"
 
 #if !defined(WIFI_SSID_MAX_LEN)
 #define WIFI_SSID_MAX_LEN		32U
@@ -78,6 +79,8 @@ struct wifi_iface_info {
 	uint8_t channel;
 	int8_t rssi;
 	enum wifi_security security;
+
+	lm_ip_info_t ip_info;
 };
 
 struct wifi_scan_result {

--- a/modules/common/include/libmcu/ip.h
+++ b/modules/common/include/libmcu/ip.h
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: 2025 권경환 Kyunghwan Kwon <k@libmcu.org>
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef LIBMCU_IP_H
+#define LIBMCU_IP_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+struct lm_ipv4 {
+	uint8_t addr[4];
+};
+
+struct lm_ipv6 {
+	uint8_t addr[16];
+	uint8_t zone;
+};
+
+struct lm_ipv4_info {
+	struct lm_ipv4 ip;
+	struct lm_ipv4 netmask;
+	struct lm_ipv4 gateway;
+};
+
+struct lm_ipv6_info {
+	struct lm_ipv6 ip;
+	struct lm_ipv6 gateway;
+	uint8_t prefix_len; /* prefix length in bits */
+};
+
+union lm_ip {
+	struct lm_ipv4 v4;
+	struct lm_ipv6 v6;
+};
+
+union lm_ip_info {
+	struct lm_ipv4_info v4;
+	struct lm_ipv6_info v6;
+};
+
+typedef union lm_ip lm_ip_t;
+typedef union lm_ip_info lm_ip_info_t;
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* LIBMCU_IP_H */


### PR DESCRIPTION
This pull request introduces a new IP handling abstraction (`libmcu/ip.h`) and integrates it into the Wi-Fi module to improve IP-related data management and consistency. The key changes include adding the new IP abstraction, updating the Wi-Fi interface structure, and modifying the ESP-IDF Wi-Fi port to use the new abstraction.

### IP Handling Abstraction:
* Added a new header file `libmcu/ip.h` defining structures and unions for IPv4, IPv6, and their associated metadata (`lm_ip_info_t` and `lm_ip_t`) to standardize IP data representation.

### Wi-Fi Interface Updates:
* Updated `struct wifi_iface_info` in `libmcu/wifi.h` to include the new `lm_ip_info_t` field for storing IP information.
* Included the new `libmcu/ip.h` header in `libmcu/wifi.h` for access to the IP handling structures.

### ESP-IDF Wi-Fi Port Modifications:
* Replaced the custom IP storage in `struct wifi` with the new `lm_ip_info_t` field, aligning with the new abstraction.
* Updated the `handle_connected_event` function to populate `lm_ip_info_t` fields (IPv4 address, gateway, and netmask) from the ESP-IDF IP event data.
* Modified the `on_wifi_events` function to reset `ip_info` on disconnection.
* Updated `get_status` to copy `ip_info` into the provided `wifi_iface_info` structure.