### PR TITLE
feat(wdt): add utility functions for watchdog management

### DIFF
--- a/interfaces/wdt/include/libmcu/wdt.h
+++ b/interfaces/wdt/include/libmcu/wdt.h
@@ -12,6 +12,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <stdbool.h>
 
 struct wdt;
 
@@ -22,6 +23,16 @@ struct wdt;
  * @param[in] ctx User-defined context for the callback.
  */
 typedef void (*wdt_timeout_cb_t)(struct wdt *wdt, void *ctx);
+
+/**
+ * @brief Callback function type for iterating over watchdog timers.
+ *
+ * This callback is invoked for each watchdog timer during iteration.
+ *
+ * @param[in] wdt Pointer to the current watchdog timer instance.
+ * @param[in] ctx User-defined context passed to the callback.
+ */
+typedef void (*wdt_foreach_cb_t)(struct wdt *wdt, void *ctx);
 
 /**
  * @typedef wdt_periodic_cb_t
@@ -148,6 +159,44 @@ int wdt_feed(struct wdt *self);
  * @return The name of the watchdog timer.
  */
 const char *wdt_name(const struct wdt *self);
+
+/**
+ * @brief Iterate over all registered watchdog timers.
+ *
+ * This function invokes the provided callback for each registered
+ * watchdog timer.
+ *
+ * @param[in] cb Callback function to be invoked for each watchdog timer.
+ * @param[in] cb_ctx User-defined context to pass to the callback.
+ */
+void wdt_foreach(wdt_foreach_cb_t cb, void *cb_ctx);
+
+/**
+ * @brief Get the timeout period of the specified watchdog timer.
+ *
+ * @param[in] self Pointer to the watchdog timer instance.
+ *
+ * @return Timeout period in milliseconds.
+ */
+uint32_t wdt_get_period(const struct wdt *self);
+
+/**
+ * @brief Get the time elapsed since the last feed of the watchdog timer.
+ *
+ * @param[in] self Pointer to the watchdog timer instance.
+ *
+ * @return Time in milliseconds since the last feed.
+ */
+uint32_t wdt_get_time_since_last_feed(const struct wdt *self);
+
+/**
+ * @brief Check if the specified watchdog timer is enabled.
+ *
+ * @param[in] self Pointer to the watchdog timer instance.
+ *
+ * @return true if the watchdog timer is enabled, false otherwise.
+ */
+bool wdt_is_enabled(const struct wdt *self);
 
 #if defined(__cplusplus)
 }

--- a/ports/esp-idf/wifi.c
+++ b/ports/esp-idf/wifi.c
@@ -324,13 +324,15 @@ static int scan_wifi(struct wifi *self)
 static int enable_wifi(struct wifi *self)
 {
 	unused(self);
-	return esp_wifi_start() == ESP_OK ? 0 : -EAGAIN;
+	esp_err_t err = esp_wifi_start();
+	return err == ESP_OK? 0 : -err;
 }
 
 static int disable_wifi(struct wifi *self)
 {
 	unused(self);
-	return esp_wifi_stop() == ESP_OK ? 0 : -EBUSY;
+	esp_err_t err = esp_wifi_stop();
+	return err == ESP_OK? 0 : -err;
 }
 
 static int get_status(struct wifi *self, struct wifi_iface_info *info)


### PR DESCRIPTION
This pull request introduces enhancements to the watchdog timer (`wdt`) functionality and makes minor improvements to the Wi-Fi module. The key changes include adding new utility functions for the `wdt` interface, implementing these functions in the ESP-IDF port, and improving error handling in the Wi-Fi module.

### Watchdog Timer Enhancements:

* **New Utility Functions in `wdt` Interface**:
  - Added `wdt_foreach_cb_t` callback type and `wdt_foreach` function to iterate over all registered watchdog timers. [[1]](diffhunk://#diff-032b2570ef43cb2b2670d62de7dd2fb6afae8995372bf444b6e1b2f3ba6abab0R27-R36) [[2]](diffhunk://#diff-032b2570ef43cb2b2670d62de7dd2fb6afae8995372bf444b6e1b2f3ba6abab0R163-R200)
  - Introduced `wdt_get_period`, `wdt_get_time_since_last_feed`, and `wdt_is_enabled` functions to retrieve timer properties and state.

* **Implementation in ESP-IDF Port**:
  - Implemented `wdt_is_enabled`, `wdt_get_period`, and `wdt_get_time_since_last_feed` functions in `wdt.c`. [[1]](diffhunk://#diff-73dff416cfe64f39bc8a2a9aca2f934e745ff0577114f6ba95082d0640576844R126-R130) [[2]](diffhunk://#diff-73dff416cfe64f39bc8a2a9aca2f934e745ff0577114f6ba95082d0640576844R179-R213)
  - Added the `wdt_foreach` function to iterate through the list of timers using a callback.

### Wi-Fi Module Improvements:

* **Error Handling**:
  - Enhanced error handling in `enable_wifi` and `disable_wifi` functions by returning the specific error code from `esp_wifi_start` and `esp_wifi_stop`.Enter concise *title* on top, update *reviewers*, *labels*, *milestone* on the side, and write up *description* below.
