### PR TITLE
test(board): add stub for board_get_current_thread

### DIFF
--- a/tests/mocks/board.cpp
+++ b/tests/mocks/board.cpp
@@ -24,3 +24,7 @@ uint32_t board_get_current_stack_watermark(void) {
 const char *board_get_serial_number_string(void) {
 	return mock().actualCall(__func__).returnStringValue();
 }
+
+void *board_get_current_thread(void) {
+	return mock().actualCall(__func__).returnPointerValue();
+}

--- a/tests/stubs/board.cpp
+++ b/tests/stubs/board.cpp
@@ -24,3 +24,7 @@ uint32_t board_get_current_stack_watermark(void) {
 const char *board_get_serial_number_string(void) {
 	return NULL;
 }
+
+void *board_get_current_thread(void) {
+	return NULL;
+}


### PR DESCRIPTION
This pull request introduces a new function, `board_get_current_thread`, to both the mock and stub implementations of the `board` module. This function provides a way to retrieve the current thread in testing and simulation contexts.

### Additions to `board` module:

* **Mock implementation (`tests/mocks/board.cpp`)**: Added the `board_get_current_thread` function, which uses the mock framework to return a pointer value for the current thread.
* **Stub implementation (`tests/stubs/board.cpp`)**: Added the `board_get_current_thread` function, which returns `NULL` as a placeholder for the current thread.