### PR TITLE
feat(board): add function to switch to factory mode

### DIFF
--- a/modules/common/include/libmcu/board.h
+++ b/modules/common/include/libmcu/board.h
@@ -78,6 +78,16 @@ void *board_get_current_thread(void);
  */
 int board_get_revision(void);
 
+/**
+ * @brief Switches the board to factory mode.
+ *
+ * This function transitions the board into factory mode, which is typically
+ * used for manufacturing or provisioning purposes.
+ *
+ * @return 0 on success, or a negative error code on failure.
+ */
+int board_switch_to_factory(void);
+
 #if defined(__cplusplus)
 }
 #endif


### PR DESCRIPTION
This pull request adds a new function declaration to the board interface for switching the board into factory mode. This is useful for manufacturing or provisioning workflows.

Board interface enhancement:

* Added the `board_switch_to_factory` function declaration to `board.h`, allowing the board to be switched into factory mode for manufacturing or provisioning purposes.