### PR TITLE
feat(tests): add new DFU mock functions for testing

### DIFF
--- a/tests/mocks/dfu.cpp
+++ b/tests/mocks/dfu.cpp
@@ -36,8 +36,30 @@ dfu_error_t dfu_abort(struct dfu *dfu) {
 		.returnIntValue();
 }
 
-dfu_error_t dfu_commit(struct dfu *dfu) {
+dfu_error_t dfu_accept(void) {
 	return (dfu_error_t)mock().actualCall(__func__)
+		.returnIntValue();
+}
+
+dfu_error_t dfu_reject_and_rollback(void) {
+	return (dfu_error_t)mock().actualCall(__func__)
+		.returnIntValue();
+}
+
+bool dfu_is_pending_verify(void) {
+	return mock().actualCall(__func__)
+		.returnBoolValue();
+}
+
+bool dfu_selftest(void) {
+	return mock().actualCall(__func__)
+		.returnBoolValue();
+}
+
+dfu_error_t dfu_register_selftest(dfu_selftest_fn_t fn, void *fn_ctx) {
+	return (dfu_error_t)mock().actualCall(__func__)
+		.withParameter("fn", fn)
+		.withParameter("fn_ctx", fn_ctx)
 		.returnIntValue();
 }
 


### PR DESCRIPTION
This pull request adds several new mock functions to the `dfu.cpp` test file to support additional DFU (Device Firmware Update) behaviors in unit tests. The main changes include new functions for accepting, rejecting, and rolling back updates, as well as support for self-testing and verifying DFU state.

New DFU mock functions:

* Added `dfu_accept` to mock accepting a DFU update, replacing the previous `dfu_commit` function.
* Added `dfu_reject_and_rollback` to mock rejecting and rolling back a DFU update.

Self-test and verification support:

* Added `dfu_is_pending_verify` to mock checking if a DFU update is pending verification.
* Added `dfu_selftest` to mock performing a DFU self-test.
* Added `dfu_register_selftest` to mock registering a self-test callback and context.