### PR TITLE
fix(metrics): add missing metrics_unset() to mocks and stubs

### DIFF
--- a/tests/mocks/metrics.cpp
+++ b/tests/mocks/metrics.cpp
@@ -2,12 +2,15 @@
 #include "libmcu/metrics.h"
 
 void metrics_increase(metric_key_t key) {
-	mock().actualCall(__func__)
-		.withParameter("key", key);
+	mock().actualCall(__func__).withParameter("key", key);
 }
 
 void metrics_set(metric_key_t key, int32_t val) {
 	mock().actualCall(__func__)
 		.withParameter("key", key)
 		.withParameter("val", val);
+}
+
+void metrics_unset(const metric_key_t key) {
+	mock().actualCall(__func__).withParameter("key", key);
 }

--- a/tests/stubs/metrics.cpp
+++ b/tests/stubs/metrics.cpp
@@ -23,6 +23,10 @@ void metrics_set_max_min(const metric_key_t k_max, const metric_key_t k_min,
 	(void)val;
 }
 
+void metrics_unset(const metric_key_t key) {
+	(void)key;
+}
+
 metric_value_t metrics_get(const metric_key_t key) {
 	(void)key;
 	return 0;


### PR DESCRIPTION
This pull request adds support for unsetting a metric key in the metrics mock and stub implementations, improving test coverage and flexibility.

**Testing improvements:**

* Added a new `metrics_unset` function to both the mock (`tests/mocks/metrics.cpp`) and stub (`tests/stubs/metrics.cpp`) files, allowing tests to simulate the removal of a metric key. [[1]](diffhunk://#diff-94abeac3ace05f79c617683a09a80b56ee66bbdd6a09958bc4b5a3b6b9471928L5-R16) [[2]](diffhunk://#diff-ccc561e91f90bcc8bc85a1e1f876df9a76a4e125138d478b59cc108342122149R26-R29)