### PR TITLE
test(timext): add mocks for ISO 8601 conversion

### DIFF
--- a/tests/mocks/timext.cpp
+++ b/tests/mocks/timext.cpp
@@ -12,3 +12,19 @@ void timeout_set(uint32_t *goal, uint32_t msec) {
 void sleep_ms(uint32_t msec) {
 	mock().actualCall(__func__).withParameter("msec", msec);
 }
+
+int iso8601_convert_to_string(time_t t, char *buf, size_t bufsize) {
+	return mock().actualCall(__func__)
+		.withParameter("t", t)
+		.withParameter("buf", buf)
+		.withParameter("bufsize", bufsize)
+		.returnIntValueOrDefault(0); // Success
+}
+
+#if defined(_GNU_SOURCE)
+time_t iso8601_convert_to_time(const char *tstr) {
+	return (time_t)mock().actualCall(__func__)
+		.withParameter("tstr", tstr)
+		.returnIntValueOrDefault(1640995200); // Default: 2022-01-01T00:00:00Z
+}
+#endif


### PR DESCRIPTION
This pull request adds mock implementations for ISO8601 time conversion functions in the `tests/mocks/timext.cpp` file to support unit testing of time-related code.

### New ISO8601 time conversion mocks

* Added a mock implementation for `iso8601_convert_to_string`, allowing tests to simulate converting a `time_t` value to an ISO8601 string.
* Added a mock implementation for `iso8601_convert_to_time` (guarded by `_GNU_SOURCE`), enabling tests to simulate parsing an ISO8601 string into a `time_t` value.